### PR TITLE
Building the direct solver for ItI problems without a source term

### DIFF
--- a/docs/PDEProblem.rst
+++ b/docs/PDEProblem.rst
@@ -16,6 +16,10 @@ The ``PDEProblem`` class has two utility functions, :func:`hahps.PDEProblem.rese
 .. note::
    In the future, I would like to make the boundary condition more explicit when initializing the ``PDEProblem``.
 
+.. note::
+   When initializing the ``PDEProblem`` class, the ``source`` argument is optional. This is because the :func:`hahps.build_solver` routine for 2D uniform ItI problems is implemented to build the solver for an arbitrary source term. In this case, :func:`hahps.solve` performs an upward pass to compute a particular solution given a new source term, and then a downward pass to compute the homogeneous solution.
+
+   If ``source`` is specified when initializing the ``PDEProblem`` instance, the :func:`hahps.build_solver` routine will only build a solver for that particular source term.
 
 .. autoclass:: hahps.PDEProblem
    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Please see our preprint `Hardware Acceleration for HPS Algorithms in Two and Thr
 If you find this work useful, please cite our paper::
 
    @misc{melia2025hahps,
-      title={Hardware Acceleration for HPS Algorithms in Two and Three Dimensions}, 
+      title={Hardware Acceleration for {HPS} Algorithms in Two and Three Dimensions}, 
       author={Owen Melia and Daniel Fortunato and Jeremy Hoskins and Rebecca Willett},
       year={2025},
       eprint={2503.17535},

--- a/examples/hp_convergence_2D_problems.py
+++ b/examples/hp_convergence_2D_problems.py
@@ -13,7 +13,6 @@ from hahps import (
     PDEProblem,
     Domain,
 )
-from src.hahps._utils import plot_soln_from_cheby_nodes
 
 # Disable all matplorlib logging
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
@@ -303,13 +302,13 @@ def problem_2(l_vals: int, p_vals: int) -> None:
             # Compute the error
             expected_soln = problem_2_soln(domain.interior_points)
 
-            # plot soln
-            plot_soln_from_cheby_nodes(
-                cheby_nodes=domain.interior_points.reshape(-1, 2),
-                corners=None,
-                expected_soln=expected_soln.real.flatten(),
-                computed_soln=computed_soln.real.flatten(),
-            )
+            # plot soln. This function can be found in src/hahps/_utils.py
+            # plot_soln_from_cheby_nodes(
+            #     cheby_nodes=domain.interior_points.reshape(-1, 2),
+            #     corners=None,
+            #     expected_soln=expected_soln.real.flatten(),
+            #     computed_soln=computed_soln.real.flatten(),
+            # )
 
             # Compute the error
             err = jnp.max(jnp.abs(computed_soln - expected_soln))

--- a/examples/hp_convergence_2D_problems.py
+++ b/examples/hp_convergence_2D_problems.py
@@ -13,6 +13,7 @@ from hahps import (
     PDEProblem,
     Domain,
 )
+from src.hahps._utils import plot_soln_from_cheby_nodes
 
 # Disable all matplorlib logging
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
@@ -303,6 +304,12 @@ def problem_2(l_vals: int, p_vals: int) -> None:
             expected_soln = problem_2_soln(domain.interior_points)
 
             # plot soln
+            plot_soln_from_cheby_nodes(
+                cheby_nodes=domain.interior_points.reshape(-1, 2),
+                corners=None,
+                expected_soln=expected_soln.real.flatten(),
+                computed_soln=computed_soln.real.flatten(),
+            )
 
             # Compute the error
             err = jnp.max(jnp.abs(computed_soln - expected_soln))

--- a/examples/hp_convergence_2D_problems.py
+++ b/examples/hp_convergence_2D_problems.py
@@ -273,7 +273,6 @@ def problem_2(l_vals: int, p_vals: int) -> None:
             domain = Domain(p=p, q=p - 2, root=root, L=l)
 
             # Create the right-hand side
-            source = problem_2_source(domain.interior_points)
 
             # Get the coefficients for the Laplacian
             lap_coeffs = problem_2_lap_coeffs(domain.interior_points)
@@ -286,7 +285,6 @@ def problem_2(l_vals: int, p_vals: int) -> None:
                 D_xx_coefficients=lap_coeffs,
                 D_yy_coefficients=lap_coeffs,
                 I_coefficients=I_term,
-                source=source,
                 use_ItI=True,
                 eta=eta,
             )
@@ -294,11 +292,12 @@ def problem_2(l_vals: int, p_vals: int) -> None:
             # Build the solver
             build_solver(pde_problem)
 
-            # Get the boundary data
+            # Get the boundary data and source
             g = problem_2_boundary_data(domain.boundary_points, eta=eta)
+            source = problem_2_source(domain.interior_points)
 
             # Solve the problem
-            computed_soln = solve(pde_problem, g)
+            computed_soln = solve(pde_problem, g, source=source)
 
             # Compute the error
             expected_soln = problem_2_soln(domain.interior_points)

--- a/src/hahps/_build_solver.py
+++ b/src/hahps/_build_solver.py
@@ -42,7 +42,9 @@ def build_solver(
     """
     This function builds all of the matrices for the fast direct solver. This comprises of
     performing a local solve stage on each leaf, and merging information from the leaves to
-    the root of the domain.
+    the root of the domain. If the ``PDEProblem`` specifies a uniform 2D ItI problem, and
+    the source term is not specified, this method will build a solver for arbitrary source terms.
+    This requires storing a few more matrices.
 
     This function performs the computation on compute_device and then transfers the data to
     host_device.

--- a/src/hahps/_build_solver.py
+++ b/src/hahps/_build_solver.py
@@ -256,7 +256,7 @@ def _nosource_build_solver(
                 "build_solver: chunk_i.source.shape = %s", chunk_i.source.shape
             )
             # Perform the local solve stage on the chunk
-            T_arr_chunk, Y_arr_chunk = (
+            Y_arr_chunk, T_arr_chunk = (
                 nosource_local_solve_stage_uniform_2D_ItI(
                     pde_problem=chunk_i,
                     device=compute_device,
@@ -273,7 +273,7 @@ def _nosource_build_solver(
         # h_host = jnp.concatenate(h_lst, axis=0)
     else:
         # Perform the local solve stage all at once for smaller problem sizes
-        T_arr_host, Y_arr_host = nosource_local_solve_stage_uniform_2D_ItI(
+        Y_arr_host, T_arr_host = nosource_local_solve_stage_uniform_2D_ItI(
             pde_problem=pde_problem,
             device=compute_device,
             host_device=host_device,

--- a/src/hahps/_build_solver.py
+++ b/src/hahps/_build_solver.py
@@ -10,6 +10,7 @@ from ._device_config import (
     local_solve_chunksize_2D,
     local_solve_chunksize_3D,
 )
+from ._discretization_tree import DiscretizationNode2D
 
 
 from .local_solve._adaptive_2D_DtN import local_solve_stage_adaptive_2D_DtN
@@ -17,6 +18,9 @@ from .local_solve._adaptive_3D_DtN import local_solve_stage_adaptive_3D_DtN
 from .local_solve._uniform_2D_DtN import local_solve_stage_uniform_2D_DtN
 from .local_solve._uniform_2D_ItI import local_solve_stage_uniform_2D_ItI
 from .local_solve._uniform_3D_DtN import local_solve_stage_uniform_3D_DtN
+from .local_solve._nosource_uniform_2D_ItI import (
+    nosource_local_solve_stage_uniform_2D_ItI,
+)
 
 
 from .merge._adaptive_2D_DtN import merge_stage_adaptive_2D_DtN
@@ -24,6 +28,7 @@ from .merge._adaptive_3D_DtN import merge_stage_adaptive_3D_DtN
 from .merge._uniform_2D_DtN import merge_stage_uniform_2D_DtN
 from .merge._uniform_2D_ItI import merge_stage_uniform_2D_ItI
 from .merge._uniform_3D_DtN import merge_stage_uniform_3D_DtN
+from .merge._nosource_uniform_2D_ItI import nosource_merge_stage_uniform_2D_ItI
 
 from ._discretization_tree import get_all_leaves
 
@@ -48,7 +53,7 @@ def build_solver(
     useful for problems, such as wave scattering, where one wants to couple the solver in
     the computational domain with a boundary integral equation defined on the domain's boundary.
 
-    To compute solutions of the PDE, one must call the solve() function after this one.
+    To compute solutions of the PDE, one must call the :func:`hahps.solve` after this one.
 
     Args:
         pde_problem (PDEProblem): Specifies the differential operator, source, domain, and precomputed interpolation and differentiation matrices.
@@ -62,6 +67,27 @@ def build_solver(
     Returns:
         None | jax.Array: If return_top_T is set to True, the function will return the computed top-level Poincare--Steklov matrix. Otherwise, it returns None.
     """
+
+    # Special code path for 2D ItI problems, for which we are implementing
+    # Upward and Downward passes.
+    if pde_problem.source is None:
+        if (
+            not pde_problem.domain.bool_uniform
+            or not isinstance(pde_problem.domain.root, DiscretizationNode2D)
+            or not pde_problem.use_ItI
+        ):
+            raise ValueError(
+                "Build stage for problems without source terms is only implemented for 2D uniform ItI problems."
+            )
+
+        else:
+            return _nosource_build_solver(
+                pde_problem=pde_problem,
+                return_top_T=return_top_T,
+                compute_device=compute_device,
+                host_device=host_device,
+            )
+
     # If it's a uniform problem, use this function. Otherwise,
     # use _adaptive_build_solver.
     if not pde_problem.domain.bool_uniform:
@@ -204,3 +230,69 @@ def _adaptive_build_solver(
 
     if return_top_T:
         return pde_problem.domain.root.data.T
+
+
+def _nosource_build_solver(
+    pde_problem: PDEProblem,
+    return_top_T: bool = False,
+    compute_device: jax.Device = DEVICE_ARR[0],
+    host_device: jax.Device = HOST_DEVICE,
+) -> None | jax.Array:
+    # Determine if batching is necessary.
+    chunksize = local_solve_chunksize_2D(pde_problem.domain.p, jnp.complex128)
+    if chunksize < pde_problem.domain.n_leaves:
+        # Do the local solve stage in batches.
+        Y_arr_lst = []
+        T_arr_lst = []
+
+        for start_idx in range(0, pde_problem.domain.n_leaves, chunksize):
+            end_idx = min(start_idx + chunksize, pde_problem.domain.n_leaves)
+
+            # Get a chunk of the PDEProblem
+            chunk_i = _get_PDEProblem_chunk(
+                pde_problem=pde_problem, start_idx=start_idx, end_idx=end_idx
+            )
+            logging.debug(
+                "build_solver: chunk_i.source.shape = %s", chunk_i.source.shape
+            )
+            # Perform the local solve stage on the chunk
+            T_arr_chunk, Y_arr_chunk = (
+                nosource_local_solve_stage_uniform_2D_ItI(
+                    pde_problem=chunk_i,
+                    device=compute_device,
+                    host_device=host_device,
+                )
+            )
+            Y_arr_lst.append(Y_arr_chunk)
+            T_arr_lst.append(T_arr_chunk)
+
+        # Concatenate the results from all chunks
+        Y_arr_host = jnp.concatenate(Y_arr_lst, axis=0)
+        T_arr_host = jnp.concatenate(T_arr_lst, axis=0)
+        # v_host = jnp.concatenate(v_lst, axis=0)
+        # h_host = jnp.concatenate(h_lst, axis=0)
+    else:
+        # Perform the local solve stage all at once for smaller problem sizes
+        T_arr_host, Y_arr_host = nosource_local_solve_stage_uniform_2D_ItI(
+            pde_problem=pde_problem,
+            device=compute_device,
+            host_device=host_device,
+        )
+    pde_problem.Y = Y_arr_host
+    # pde_problem.v = v_host
+
+    # Perform the merge stage
+    merge_out = nosource_merge_stage_uniform_2D_ItI(
+        T_arr_host,
+        l=pde_problem.domain.L,
+        device=compute_device,
+        host_device=host_device,
+        return_T=return_top_T,
+    )
+    pde_problem.S_lst = merge_out[0]
+    pde_problem.D_inv_lst = merge_out[1]
+    pde_problem.BD_inv_lst = merge_out[2]
+    if return_top_T:
+        return merge_out[3]
+    else:
+        return None

--- a/src/hahps/_pdeproblem.py
+++ b/src/hahps/_pdeproblem.py
@@ -44,6 +44,10 @@ class PDEProblem:
         self.domain: Domain = domain  #: The domain, which contains information about the discretization.
 
         # Input validation
+        # If it's not an ItI problem, we need to check the source term exists
+        if not use_ItI and source is None:
+            raise ValueError("Source must be specified for non-ItI problems.")
+
         # 2D problems shouldn't specify D_z_coefficients
         if isinstance(domain.root, DiscretizationNode3D):
             bool_2D = False
@@ -234,6 +238,8 @@ class PDEProblem:
         self.v = None
         self.S_lst = []
         self.g_tilde_lst = []
+        self.D_inv_lst = []
+        self.BD_inv_lst = []
 
     def update_coefficients(
         self,

--- a/src/hahps/_solve.py
+++ b/src/hahps/_solve.py
@@ -25,7 +25,9 @@ def solve(
 ) -> jax.Array:
     """
     This function performs the downward pass of the HPS algorithm, after the solution operators have
-    been formed by a call to hahps.build_solver().
+    been formed by a call to :func:`hahps.build_solver`.
+
+    If the problem is a 2D uniform ItI problem, the source term can be specified here. For other problems, the source term must be specified at the time the solver is built.
 
 
     Args:

--- a/src/hahps/_solve.py
+++ b/src/hahps/_solve.py
@@ -13,11 +13,13 @@ from .down_pass._adaptive_3D_DtN import down_pass_adaptive_3D_DtN
 from .down_pass._uniform_2D_DtN import down_pass_uniform_2D_DtN
 from .down_pass._uniform_2D_ItI import down_pass_uniform_2D_ItI
 from .down_pass._uniform_3D_DtN import down_pass_uniform_3D_DtN
+from .up_pass._uniform_2D_ItI import up_pass_uniform_2D_ItI
 
 
 def solve(
     pde_problem: PDEProblem,
     boundary_data: jax.Array | List[jax.Array],
+    source: jax.Array = None,
     compute_device: jax.Device = DEVICE_ARR[0],
     host_device: jax.Device = HOST_DEVICE,
 ) -> jax.Array:
@@ -29,7 +31,10 @@ def solve(
     Args:
         pde_problem (PDEProblem): Specifies the differential operator, source, domain, and precomputed interpolation and differentiation matrices. Also contains all of the solution operators computed by hahps.build_solver().
 
+
         boundary_data (jax.Array | List[jax.Array]): This specifies the data on the boundary of the domain that will be propagated down to the interior of the leaves. If using an adaptive discretization, this must be specified as a list of arrays, one for each side or face of the root boundary. This list can be specified using the Domain.get_adaptive_boundary_data_lst() utility. For uniform discretizations, this argument can be a jax.Array of shape (n_bdry,) or a list.
+
+        source (jax.Array): The source term for the PDE. Currently, this can only be specified for 2D uniform ItI problems. For other versions, the source must be specified at the time the solver is built.
 
         compute_device (jax.Device, optional): Where the computation should happen. Defaults to jax.devices()[0].
 
@@ -38,6 +43,20 @@ def solve(
     Returns:
         jax.Array: The solution on the HPS grid. This has shape (n_leaves, p^d).
     """
+    if source is not None:
+        # Check that we're dealing with a 2D uniform ItI problem
+        if not pde_problem.domain.bool_2D or not pde_problem.use_ItI:
+            raise ValueError(
+                "Source can only be specified for 2D uniform ItI problems. For other problems, the source must be specified at the time the solver is built."
+            )
+        return _up_then_down_pass(
+            pde_problem=pde_problem,
+            boundary_data=boundary_data,
+            source=source,
+            compute_device=compute_device,
+            host_device=host_device,
+        )
+
     if not pde_problem.domain.bool_uniform:
         # interface is different for the adaptive down pass so we'll
         # pass to a different function.
@@ -87,3 +106,31 @@ def _adaptive_solve(
     return down_pass_fn(
         pde_problem=pde_problem, boundary_data=boundary_data_lst
     )
+
+
+def _up_then_down_pass(
+    pde_problem: PDEProblem,
+    boundary_data: jax.Array,
+    source: jax.Array,
+    compute_device: jax.Device,
+    host_device: jax.Device,
+) -> jax.Array:
+    # First, do the upward pass
+    v, g_tilde_lst = up_pass_uniform_2D_ItI(
+        pde_problem=pde_problem,
+        source=source,
+        device=compute_device,
+        host_device=host_device,
+    )
+
+    # Now, do the downward pass
+    solns = down_pass_uniform_2D_ItI(
+        boundary_imp_data=boundary_data,
+        S_lst=pde_problem.S_lst,
+        g_tilde_lst=g_tilde_lst,
+        Y_arr=pde_problem.Y,
+        v_arr=v,
+        device=compute_device,
+        host_device=host_device,
+    )
+    return solns

--- a/src/hahps/local_solve/_nosource_uniform_2D_ItI.py
+++ b/src/hahps/local_solve/_nosource_uniform_2D_ItI.py
@@ -1,0 +1,138 @@
+import jax.numpy as jnp
+import jax
+
+from .._pdeproblem import PDEProblem
+from .._device_config import DEVICE_ARR, HOST_DEVICE
+from ._uniform_2D_DtN import _gather_coeffs_2D, vmapped_assemble_diff_operator
+from typing import Tuple
+
+
+def nosource_local_solve_stage_uniform_2D_ItI(
+    pde_problem: PDEProblem,
+    device: jax.Device = DEVICE_ARR[0],
+    host_device: jax.Device = HOST_DEVICE,
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    """
+    This function performs the local solve stage for 2D problems with a uniform quadtree, creating ItI matrices.
+
+    Parameters
+    ----------
+    pde_problem : PDEProblem
+        Specifies the discretization, differential operator, source function, and keeps track of the pre-computed differentiation and interpolation matrices.
+    device : jax.Device
+        Where to perform the computation. Defaults to ``jax.devices()[0]``.
+    host_device : jax.Device
+        Where to place the output. Defaults to ``jax.devices("cpu")[0]``.
+
+    Returns
+    -------
+    Y : jax.Array
+        Solution operators mapping from Impedance boundary data to homogeneous solutions on the leaf interiors. Has shape (n_leaves, p^2, 4q)
+    T : jax.Array
+        Impedance-to-Impedance matrices for each leaf. Has shape (n_leaves, 4q, 4q)
+    """
+
+    # Gather the coefficients into a single array.
+    coeffs_gathered, which_coeffs = _gather_coeffs_2D(
+        D_xx_coeffs=pde_problem.D_xx_coefficients,
+        D_xy_coeffs=pde_problem.D_xy_coefficients,
+        D_yy_coeffs=pde_problem.D_yy_coefficients,
+        D_x_coeffs=pde_problem.D_x_coefficients,
+        D_y_coeffs=pde_problem.D_y_coefficients,
+        I_coeffs=pde_problem.I_coefficients,
+    )
+    # stack the precomputed differential operators into a single array
+    diff_ops = jnp.stack(
+        [
+            pde_problem.D_xx,
+            pde_problem.D_xy,
+            pde_problem.D_yy,
+            pde_problem.D_x,
+            pde_problem.D_y,
+            jnp.eye(pde_problem.D_xx.shape[0], dtype=jnp.float64),
+        ]
+    )
+
+    coeffs_gathered = jax.device_put(
+        coeffs_gathered,
+        device,
+    )
+
+    all_diff_operators = vmapped_assemble_diff_operator(
+        coeffs_gathered, which_coeffs, diff_ops
+    )
+
+    R_arr, Y_arr = vmapped_get_ItI_nosource(
+        all_diff_operators,
+        pde_problem.P,
+        pde_problem.QH,
+        pde_problem.G,
+    )
+
+    R_arr_host = jax.device_put(R_arr, host_device)
+    Y_arr_host = jax.device_put(Y_arr, host_device)
+
+    return R_arr_host, Y_arr_host
+
+
+@jax.jit
+def get_ItI_nosource(
+    diff_operator: jax.Array,
+    P: jax.Array,
+    QH: jax.Array,
+    G: jax.Array,
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    """Given the coefficients specifying a partial differential operator on a leaf, this function
+    computes the particular solution, particular solution boundary fluxes, the
+    impedance to impedance map, and the impedance to solution map.
+
+    Args:
+        coeffs_arr (jax.Array): Has shape (?, p**2). Specifies the PDE coefficients.
+        source_term (jax.Array): Has shape (p**2, n_sources). Specifies the RHS of the PDE.
+        diff_ops (jax.Array): Has shape (5, p**2, p**2). Contains the precomputed differential operators. In 3D,
+                                this has shape (9, p**3, p**3).
+        which_coeffs (jax.Array): Has shape (5,) and specifies which coefficients are not None.
+        P (jax.Array): Has shape (4(p-1), 4q). Maps data on the Gauss boundary nodes to data on the Cheby boundary nodes.
+                            Is formed by taking the kronecker product of I and P_0, which is the standard
+                            Gauss -> Cheby 1D interp matrix missing the last row.
+        QH (jax.Array): Has shape (4q, p**2). Maps a function on the Chebyshev nodes to the function's outgoing impedance
+                    on the boundary Gauss nodes.
+        G (jax.Array): Has shape (4(p-1), p**2). Maps a function on the Chebyshev nodes to the function's incoming
+                    impedance on the boundary Cheby nodes, counting corners once.
+
+    Returns:
+        Tuple[jax.Array]:
+            T (jax.Array): Has shape (4q, 4q). This is the "ItI" operator, which maps incoming impedance data on the
+                boundary Gauss nodes to the outgoing impedance data on the boundary Gauss nodes.
+            Y (jax.Array): Has shape (p**2, 4q). This is the interior solution operator, which maps from incoming impedance
+                data on the boundary Gauss nodes to the resulting homogeneous solution on the Chebyshev nodes.
+
+    """
+    # print("get_ItI: I_P_0 shape: ", I_P_0.shape)
+    # print("get_ItI: Q_I shape: ", Q_I.shape)
+    n_cheby_pts = diff_operator.shape[-1]
+    n_cheby_bdry_pts = P.shape[0]
+    A = diff_operator
+
+    # B has shape (n_cheby_pts, n_cheby_pts). Its top rows are F and its bottom rows are the
+    # bottom rows of A.
+    B = jnp.zeros((n_cheby_pts, n_cheby_pts), dtype=jnp.complex128)
+    B = B.at[:n_cheby_bdry_pts].set(G)
+    B = B.at[n_cheby_bdry_pts:].set(A[n_cheby_bdry_pts:])
+    B_inv = jnp.linalg.inv(B)
+
+    # Y has shape (n_cheby_pts, n_cheby_bdry_pts). It maps from
+    # incoming impedance data on the boundary G-L nodes to the
+    # homogeneous solution on all of the Cheby nodes.
+    Y = B_inv[:, :n_cheby_bdry_pts] @ P
+
+    # Interpolate to Gauss nodes
+    T = QH @ Y
+    return (T, Y)
+
+
+vmapped_get_ItI_nosource = jax.vmap(
+    get_ItI_nosource,
+    in_axes=(0, None, None, None),
+    out_axes=(0, 0),
+)

--- a/src/hahps/local_solve/_nosource_uniform_2D_ItI.py
+++ b/src/hahps/local_solve/_nosource_uniform_2D_ItI.py
@@ -72,7 +72,7 @@ def nosource_local_solve_stage_uniform_2D_ItI(
     R_arr_host = jax.device_put(R_arr, host_device)
     Y_arr_host = jax.device_put(Y_arr, host_device)
 
-    return R_arr_host, Y_arr_host
+    return Y_arr_host, R_arr_host
 
 
 @jax.jit

--- a/src/hahps/merge/_nosource_uniform_2D_ItI.py
+++ b/src/hahps/merge/_nosource_uniform_2D_ItI.py
@@ -1,0 +1,343 @@
+from typing import Tuple, List
+
+import jax
+import jax.numpy as jnp
+
+
+from ._schur_complement import (
+    nosource_assemble_merge_outputs_ItI,
+)
+from .._device_config import DEVICE_ARR, HOST_DEVICE
+from ._uniform_2D_DtN import (
+    get_quadmerge_blocks_a,
+    get_quadmerge_blocks_b,
+    get_quadmerge_blocks_c,
+    get_quadmerge_blocks_d,
+)
+import logging
+
+
+def nosource_merge_stage_uniform_2D_ItI(
+    T_arr: jnp.array,
+    l: int,
+    device: jax.Device = DEVICE_ARR[0],
+    host_device: jax.Device = HOST_DEVICE,
+    return_T: bool = False,
+) -> Tuple[List[jnp.ndarray], List[jnp.ndarray], List[jnp.ndarray]]:
+    """
+    Implements uniform 2D merges of ItI matrices. Merges the nodes in the quadtree four at a time.
+    This function uses a Schur complement strategy to reduce the size of matrix inverted in each merge operation.
+    This function returns lists containing :math:`S` and :math:`\\tilde{g}`, giving enough information
+    to propagate boundary data back down the tree in a later part of the algorithm.
+
+    If this function is called with the argument ``return_T=True``, the top-level DtN matrix is also returned.
+
+    Parameters
+    ----------
+    pde_problem : PDEProblem
+        Specifies the discretization, differential operator, source function, and keeps track of the pre-computed differentiation and interpolation matrices.
+
+    T_arr : jax.Array
+        Array of ItI matrices from the local solve stage. Has shape (n_leaves, 4q, 4q)
+
+    l : int
+        Number of levels to merge
+
+    device : jax.Device
+        Where to perform the computation. Defaults to jax.devices()[0].
+
+    host_device : jax.Device
+        Where to place the output. Defaults to jax.devices("cpu")[0].
+
+    return_T : bool
+        A flag to return the top-level T matrix. Defaults to False.
+
+    Returns
+    -------
+    S_lst : List[jax.Array]
+        A list of propagation operators. The first element of the list are the propagation operators for the nodes just above the leaves, and the last element of the list is the propagation operator for the root of the quadtree.
+
+    D_inv_lst : List[jax.Array]
+        List of pre-computed D^{-1} matrices for each level of the quadtree.
+
+    BD_inverse_lst : List[jax.Array]
+        List of pre-computed BD^{-1} matrices for each level of the quadtree.
+
+    T_last : jax.Array
+        The top-level DtN matrix, which is only returned if ``return_T=True``. Has shape (4q, 4q).
+
+    """
+
+    # Start lists to output data
+    S_lst = []
+    D_inv_lst = []
+    BD_inverse_lst = []
+
+    T_arr = jax.device_put(T_arr, device)
+
+    if len(T_arr.shape) < 4:
+        logging.debug(
+            "merge_stage_uniform_2D_ItI: T_arr.shape = %s", T_arr.shape
+        )
+        n_leaves, n_ext, _ = T_arr.shape
+        T_arr = T_arr.reshape(n_leaves // 4, 4, n_ext, n_ext)
+
+    for i in range(l - 1):
+        S_arr, T_arr_new, D_inv_arr, BD_inv_arr = (
+            vmapped_nosource_uniform_quad_merge_ItI(T_arr)
+        )
+
+        # TODO: Figure out how to safely delete these arrays
+        # when using autodiff.
+
+        # T_arr.delete()
+        # h_arr.delete()
+
+        if host_device != device:
+            S_host = jax.device_put(S_arr, host_device)
+            S_lst.append(S_host)
+            S_arr.delete()
+
+            D_inv_host = jax.device_put(D_inv_arr, host_device)
+            D_inv_lst.append(D_inv_host)
+            D_inv_arr.delete()
+
+            BD_inv_host = jax.device_put(BD_inv_arr, host_device)
+            BD_inverse_lst.append(BD_inv_host)
+            BD_inv_arr.delete()
+        else:
+            S_lst.append(S_arr)
+            D_inv_lst.append(D_inv_arr)
+            BD_inverse_lst.append(BD_inv_arr)
+
+        T_arr = T_arr_new
+
+    S_last, T_last, D_inv_last, BD_inv_last = _nosource_uniform_quad_merge_ItI(
+        T_arr[0, 0],
+        T_arr[0, 1],
+        T_arr[0, 2],
+        T_arr[0, 3],
+    )
+
+    S_lst.append(jax.device_put(jnp.expand_dims(S_last, axis=0), host_device))
+    D_inv_lst.append(jax.device_put(D_inv_last, host_device))
+    BD_inverse_lst.append(jax.device_put(BD_inv_last, host_device))
+
+    if return_T:
+        T_last_out = jax.device_put(T_last, host_device)
+        return (S_lst, D_inv_lst, BD_inverse_lst, T_last_out)
+    else:
+        return (S_lst, D_inv_lst, BD_inverse_lst)
+
+
+@jax.jit
+def _nosource_uniform_quad_merge_ItI(
+    R_a: jnp.array,
+    R_b: jnp.array,
+    R_c: jnp.array,
+    R_d: jnp.array,
+) -> Tuple[jnp.array, jnp.array, jnp.array, jnp.array]:
+    n_a = R_a.shape[0]
+    dummy_h = jnp.zeros((n_a,), dtype=R_a.dtype)
+    # First, find all of the necessary submatrices and sub-vectors
+    (
+        _,
+        _,
+        _,
+        R_a_11,
+        R_a_15,
+        R_a_18,
+        R_a_51,
+        R_a_55,
+        R_a_58,
+        R_a_81,
+        R_a_85,
+        R_a_88,
+    ) = get_quadmerge_blocks_a(R_a, dummy_h)
+
+    (
+        _,
+        _,
+        _,
+        R_b_22,
+        R_b_26,
+        R_b_25,
+        R_b_62,
+        R_b_66,
+        R_b_65,
+        R_b_52,
+        R_b_56,
+        R_b_55,
+    ) = get_quadmerge_blocks_b(R_b, dummy_h)
+
+    (
+        _,
+        _,
+        _,
+        R_c_66,
+        R_c_63,
+        R_c_67,
+        R_c_36,
+        R_c_33,
+        R_c_37,
+        R_c_76,
+        R_c_73,
+        R_c_77,
+    ) = get_quadmerge_blocks_c(R_c, dummy_h)
+
+    (
+        _,
+        _,
+        _,
+        R_d_88,
+        R_d_87,
+        R_d_84,
+        R_d_78,
+        R_d_77,
+        R_d_74,
+        R_d_48,
+        R_d_47,
+        R_d_44,
+    ) = get_quadmerge_blocks_d(R_d, dummy_h)
+
+    n_int, n_ext = R_a_51.shape
+
+    zero_block_ei = jnp.zeros((n_ext, n_int))
+    zero_block_ie = jnp.zeros((n_int, n_ext))
+    zero_block_ii = jnp.zeros((n_int, n_int))
+
+    # print("_quad_merge_ItI: h_a_1", h_a_1.shape)
+
+    # A t_ext + B t_int = g_ext - h_ext
+    B = jnp.block(
+        [
+            [
+                R_a_15,
+                R_a_18,
+                zero_block_ei,
+                zero_block_ei,
+                zero_block_ei,
+                zero_block_ei,
+                zero_block_ei,
+                zero_block_ei,
+            ],
+            [
+                zero_block_ei,
+                zero_block_ei,
+                zero_block_ei,
+                zero_block_ei,
+                R_b_25,
+                R_b_26,
+                zero_block_ei,
+                zero_block_ei,
+            ],
+            [
+                zero_block_ei,
+                zero_block_ei,
+                R_c_36,
+                R_c_37,
+                zero_block_ei,
+                zero_block_ei,
+                zero_block_ei,
+                zero_block_ei,
+            ],
+            [
+                zero_block_ei,
+                zero_block_ei,
+                zero_block_ei,
+                zero_block_ei,
+                zero_block_ei,
+                zero_block_ei,
+                R_d_47,
+                R_d_48,
+            ],
+        ]
+    )
+
+    # C t_ext + D t_int + h_int = 0
+    C = jnp.block(
+        [
+            [zero_block_ie, R_b_52, zero_block_ie, zero_block_ie],
+            [zero_block_ie, zero_block_ie, zero_block_ie, R_d_84],
+            [zero_block_ie, R_b_62, zero_block_ie, zero_block_ie],
+            [zero_block_ie, zero_block_ie, zero_block_ie, R_d_74],
+            [R_a_51, zero_block_ie, zero_block_ie, zero_block_ie],
+            [zero_block_ie, zero_block_ie, R_c_63, zero_block_ie],
+            [zero_block_ie, zero_block_ie, R_c_73, zero_block_ie],
+            [R_a_81, zero_block_ie, zero_block_ie, zero_block_ie],
+        ]
+    )
+
+    D_12 = jnp.block(
+        [
+            [R_b_55, R_b_56, zero_block_ii, zero_block_ii],
+            [zero_block_ii, zero_block_ii, R_d_87, R_d_88],
+            [R_b_65, R_b_66, zero_block_ii, zero_block_ii],
+            [zero_block_ii, zero_block_ii, R_d_77, R_d_78],
+        ]
+    )
+
+    D_21 = jnp.block(
+        [
+            [R_a_55, R_a_58, zero_block_ii, zero_block_ii],
+            [zero_block_ii, zero_block_ii, R_c_66, R_c_67],
+            [zero_block_ii, zero_block_ii, R_c_76, R_c_77],
+            [R_a_85, R_a_88, zero_block_ii, zero_block_ii],
+        ]
+    )
+
+    A_lst = [R_a_11, R_b_22, R_c_33, R_d_44]
+
+    T, S, D_inv, BD_inv = nosource_assemble_merge_outputs_ItI(
+        A_lst, B, C, D_12, D_21
+    )
+
+    # Roll the exterior by n_int to get the correct ordering
+    T = jnp.roll(T, -n_int, axis=0)
+    T = jnp.roll(T, -n_int, axis=1)
+    S = jnp.roll(S, -n_int, axis=1)
+
+    BD_inv = jnp.roll(BD_inv, -n_int, axis=0)
+
+    # rows of S and D_inv are ordered like a_5, a_8, c_6, c_7, b_5, b_6, d_7, d_8.
+    # Want to rearrange them so they are ordered like
+    # a_5, b_5, b_6, c_6, c_7, d_7, d_8, a_8
+    r = jnp.concatenate(
+        [
+            jnp.arange(n_int),  # a5
+            jnp.arange(4 * n_int, 5 * n_int),  # b5
+            jnp.arange(5 * n_int, 6 * n_int),  # b6
+            jnp.arange(2 * n_int, 3 * n_int),  # c6
+            jnp.arange(3 * n_int, 4 * n_int),  # c7
+            jnp.arange(6 * n_int, 7 * n_int),  # d7
+            jnp.arange(7 * n_int, 8 * n_int),  # d8
+            jnp.arange(n_int, 2 * n_int),  # a8
+        ]
+    )
+    S = S[r]
+    D_inv = D_inv[r]
+
+    return S, T, D_inv, BD_inv
+
+
+_vmapped_nosource_uniform_quad_merge_ItI = jax.vmap(
+    _nosource_uniform_quad_merge_ItI,
+    in_axes=(0, 0, 0, 0),
+    out_axes=(0, 0, 0, 0),
+)
+
+
+@jax.jit
+def vmapped_nosource_uniform_quad_merge_ItI(
+    R_in: jnp.array,
+) -> Tuple[jnp.array, jnp.array, jnp.array, jnp.array]:
+    S, R, D_inv, BD_inv = _vmapped_nosource_uniform_quad_merge_ItI(
+        R_in[:, 0],
+        R_in[:, 1],
+        R_in[:, 2],
+        R_in[:, 3],
+    )
+
+    n_merges, n_int, n_ext = S.shape
+    R = R.reshape((n_merges // 4, 4, n_ext, n_ext))
+    return S, R, D_inv, BD_inv

--- a/src/hahps/merge/_nosource_uniform_2D_ItI.py
+++ b/src/hahps/merge/_nosource_uniform_2D_ItI.py
@@ -120,8 +120,12 @@ def nosource_merge_stage_uniform_2D_ItI(
     )
 
     S_lst.append(jax.device_put(jnp.expand_dims(S_last, axis=0), host_device))
-    D_inv_lst.append(jax.device_put(D_inv_last, host_device))
-    BD_inverse_lst.append(jax.device_put(BD_inv_last, host_device))
+    D_inv_lst.append(
+        jax.device_put(jnp.expand_dims(D_inv_last, axis=0), host_device)
+    )
+    BD_inverse_lst.append(
+        jax.device_put(jnp.expand_dims(BD_inv_last, axis=0), host_device)
+    )
 
     if return_T:
         T_last_out = jax.device_put(T_last, host_device)

--- a/src/hahps/merge/_nosource_uniform_2D_ItI.py
+++ b/src/hahps/merge/_nosource_uniform_2D_ItI.py
@@ -34,8 +34,6 @@ def nosource_merge_stage_uniform_2D_ItI(
 
     Parameters
     ----------
-    pde_problem : PDEProblem
-        Specifies the discretization, differential operator, source function, and keeps track of the pre-computed differentiation and interpolation matrices.
 
     T_arr : jax.Array
         Array of ItI matrices from the local solve stage. Has shape (n_leaves, 4q, 4q)

--- a/src/hahps/merge/_nosource_uniform_2D_ItI.py
+++ b/src/hahps/merge/_nosource_uniform_2D_ItI.py
@@ -295,11 +295,12 @@ def _nosource_uniform_quad_merge_ItI(
     )
 
     # Roll the exterior by n_int to get the correct ordering
+    # of the exterior discretization points. Right now, the exterior points are ordered like [a_1, b_2, c_3, d_4]
+    # but we want [bottom, left, top, right]. This requires
+    # rolling the exterior points by n_int.
     T = jnp.roll(T, -n_int, axis=0)
     T = jnp.roll(T, -n_int, axis=1)
     S = jnp.roll(S, -n_int, axis=1)
-
-    BD_inv = jnp.roll(BD_inv, -n_int, axis=0)
 
     # rows of S and D_inv are ordered like a_5, a_8, c_6, c_7, b_5, b_6, d_7, d_8.
     # Want to rearrange them so they are ordered like
@@ -317,7 +318,6 @@ def _nosource_uniform_quad_merge_ItI(
         ]
     )
     S = S[r]
-    D_inv = D_inv[r]
 
     return S, T, D_inv, BD_inv
 

--- a/src/hahps/up_pass/__init__.py
+++ b/src/hahps/up_pass/__init__.py
@@ -1,0 +1,5 @@
+from ._uniform_2D_ItI import up_pass_uniform_2D_ItI
+
+__all__ = [
+    "up_pass_uniform_2D_ItI",
+]

--- a/src/hahps/up_pass/_uniform_2D_ItI.py
+++ b/src/hahps/up_pass/_uniform_2D_ItI.py
@@ -1,0 +1,83 @@
+from typing import List, Tuple
+
+import jax
+
+from .._device_config import HOST_DEVICE, DEVICE_ARR
+from .._pdeproblem import PDEProblem
+from ..local_solve._uniform_2D_ItI import local_solve_stage_uniform_2D_ItI
+
+
+def up_pass_uniform_2D_ItI(
+    source: jax.Array,
+    pde_problem: PDEProblem,
+    D_inv_lst: List[jax.Array],
+    BD_inv_lst: List[jax.Array],
+    device: jax.Device = DEVICE_ARR[0],
+    host_device: jax.Device = HOST_DEVICE,
+) -> Tuple[jax.Array, List[jax.Array]]:
+    """
+    This function performs the upward pass for 2D ItI problems. It recomputes the local solve stage to get
+    outgoing impedance data from the particular solution, which is now known because the source is specified.
+
+
+
+    Parameters
+    ----------
+    source : jax.Array
+        _description_
+
+    pde_probem : PDEProblem
+        Specifies the discretization, differential operator, source function, and keeps track of the pre-computed differentiation and interpolation matrices.
+
+    D_inv_lst : List[jax.Array]
+        List of pre-computed D^{-1} matrices for each level of the quadtree.
+
+    BD_inv_lst : List[jax.Array]
+        List of pre-computed BD^{-1} matrices for each level of the quadtree.
+
+    device : jax.Device, optional
+        Where to perform the computation. Defaults to ``jax.devices()[0]``.
+
+    host_device : jax.Device, optional
+        Where to place the output. Defaults to ``jax.devices("cpu")[0]``.
+
+    Returns
+    -------
+    v : jax.Array
+        Leaf-level particular solutions. Has shape (n_leaves, p^2)
+
+    g_tilde_lst : List[jax.Array]
+        List of pre-computed g_tilde matrices for each level of the quadtree.
+    """
+
+    # Re-do a full local solve.
+    pde_problem.source = source
+
+    Y, T, v, h = local_solve_stage_uniform_2D_ItI(
+        pde_problem=pde_problem,
+        device=device,
+        host_device=host_device,
+    )
+
+
+@jax.jit
+def assemble_boundary_data(
+    h_in: jax.Array,
+    D_inv: jax.Array,
+    BD_inv: jax.Array,
+) -> Tuple[jax.Array, jax.Array]:
+    """
+
+
+    Args:
+        h_in (jax.Array): Has shape (4, 4 * nside) where nside is the number of discretization points along each side of the nodes being merged.
+        D_inv (jax.Array): Has shape (8 * nside, 8 * nside)
+        BD_inv (jax.Array): Has shape (8 * nside, 8 * nside)
+
+    Returns:
+        h : jax.Array
+            Has shape (8 * nside) and is the outgoing impedance data due to the particular solution on the merged node.
+        g_tilde : jax.Array
+            Has shape (8 * nside) and is the incoming impedance data due to the particular solution on the merged node, evaluated along the merge interfaces.
+    """
+    pass

--- a/src/hahps/up_pass/_uniform_2D_ItI.py
+++ b/src/hahps/up_pass/_uniform_2D_ItI.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple
 import jax
 import jax.numpy as jnp
-
+import logging
 from .._device_config import HOST_DEVICE, DEVICE_ARR
 from .._pdeproblem import PDEProblem
 from ..local_solve._uniform_2D_ItI import local_solve_stage_uniform_2D_ItI
@@ -59,10 +59,15 @@ def up_pass_uniform_2D_ItI(
 
     for i in range(len(D_inv_lst)):
         # Get h and g_tilde for this level
+        logging.debug("up_pass_uniform_2D_ItI: i: %s", i)
+        logging.debug("up_pass_uniform_2D_ItI: h_in shape: %s", h_in.shape)
         nbdry = h_in.shape[-1]
         h_in = h_in.reshape(4, -1, nbdry)
         D_inv = D_inv_lst[i]
         BD_inv = BD_inv_lst[i]
+        logging.debug("up_pass_uniform_2D_ItI: D_inv shape: %s", D_inv.shape)
+        logging.debug("up_pass_uniform_2D_ItI: BD_inv shape: %s", BD_inv.shape)
+        logging.debug("up_pass_uniform_2D_ItI: h_in shape: %s", h_in.shape)
         h_in, g_tilde = vmapped_assemble_boundary_data(h_in, D_inv, BD_inv)
         g_tilde_lst.append(g_tilde)
 

--- a/tests/test_accuracy/cases.py
+++ b/tests/test_accuracy/cases.py
@@ -1,5 +1,5 @@
 import jax.numpy as jnp
-
+import jax
 
 ####################################################################
 # Define the keys that will be used in the test cases
@@ -18,6 +18,8 @@ K_SOLN = "soln_fn"
 K_PART_SOLN_DUDX = "d_dx_part_soln_fn"
 K_PART_SOLN_DUDY = "d_dy_part_soln_fn"
 K_PART_SOLN_DUDZ = "d_dz_part_soln_fn"
+K_DUDX = "d_dx_soln_fn"
+K_DUDY = "d_dy_soln_fn"
 
 
 ######################################################################
@@ -152,10 +154,8 @@ def q(x):
 
 
 def f(x):
-    # f(x,y) = - pi^2 (  e^{i \pi x} + e^{i \pi y} )
-    return -(jnp.pi**2) * (
-        jnp.exp(1j * jnp.pi * x[..., 0]) + jnp.exp(1j * jnp.pi * x[..., 1])
-    )
+    # f(x,y) = - pi^2 u(x) + q(x) u(x)
+    return -(jnp.pi**2) * u(x) + q(x) * u(x)
 
 
 def u(x):
@@ -189,11 +189,21 @@ def g(x: jnp.array) -> jnp.array:
     return dudn + 1j * ETA * u(x)
 
 
-TEST_CASE_PART_ITI = {
+def dudx(x: jax.Array) -> jax.Array:
+    return 1j * jnp.pi * jnp.exp(1j * jnp.pi * x[..., 0])
+
+
+def dudy(x: jax.Array) -> jax.Array:
+    return 1j * jnp.pi * jnp.exp(1j * jnp.pi * x[..., 1])
+
+
+TEST_CASE_HELMHOLTZ_ITI = {
     K_DIRICHLET: g,
     K_XX_COEFF: default_lap_coeffs,
     K_YY_COEFF: default_lap_coeffs,
     K_I_COEFF: q,
     K_SOURCE: f,
     K_SOLN: u,
+    K_DUDX: dudx,
+    K_DUDY: dudy,
 }

--- a/tests/test_accuracy/cases.py
+++ b/tests/test_accuracy/cases.py
@@ -7,6 +7,7 @@ K_DIRICHLET = "dirichlet_data_fn"
 K_XX_COEFF = "d_xx_coeff_fn"
 K_YY_COEFF = "d_yy_coeff_fn"
 K_ZZ_COEFF = "d_zz_coeff_fn"
+K_I_COEFF = "i_coeff_fn"
 K_SOURCE = "source_fn"
 K_DIRICHLET_DUDX = "d_dx_dirichlet_data_fn"
 K_DIRICHLET_DUDY = "d_dy_dirichlet_data_fn"
@@ -125,4 +126,52 @@ TEST_CASE_POLY_ZERO_SOURCE = {
     K_PART_SOLN: lambda x: jnp.expand_dims(jnp.zeros_like(x[..., 0]), -1),
     K_PART_SOLN_DUDX: lambda x: jnp.expand_dims(jnp.zeros_like(x[..., 0]), -1),
     K_PART_SOLN_DUDY: lambda x: jnp.expand_dims(jnp.zeros_like(x[..., 0]), -1),
+}
+
+
+# ######################################################################
+# # Test Case 2: Polynomial Source Function for ItI Problems
+# # \Delta u + q(x) u(x) = f     in \Omega
+# # u_n + i u = 0                in \partial \Omega
+# #
+# #
+# # q(x,y) = 1 + e^{- \lambda_1 ||x||^2}
+# # f(x,y) = - pi^2 (  e^{i \pi x} + e^{i \pi y} )
+# # g(x,y) = defined piecewise
+# # Can't separate the solution into homogeneous and particular parts, but here
+# # is the solution:
+# # u(x,y) = e^{i  \pi x} + e^{i  \pi y}
+
+
+def part_soln_iti_fn(x: jnp.ndarray) -> jnp.ndarray:
+    # v(x,y) = (x^2 + 2i x) + (y^2 + 2i y)
+    return (
+        jnp.square(x[..., 0])
+        + 2j * x[..., 0]
+        + jnp.square(x[..., 1])
+        + 2j * x[..., 1]
+    )
+
+
+def part_soln_iti_dudx_fn(x: jnp.ndarray) -> jnp.ndarray:
+    # dv/dx = 2x + 2i
+    return jnp.expand_dims(2 * x[..., 0] + 2j, -1)
+
+
+def part_soln_iti_dudy_fn(x: jnp.ndarray) -> jnp.ndarray:
+    # dv/dy = 2y + 2i
+    return jnp.expand_dims(2 * x[..., 1] + 2j, -1)
+
+
+TEST_CASE_PART_ITI = {
+    K_DIRICHLET: lambda x: jnp.zeros_like(x[..., 0]),
+    K_DIRICHLET_DUDX: lambda x: jnp.zeros_like(x[..., 0]),
+    K_DIRICHLET_DUDY: lambda x: jnp.zeros_like(x[..., 0]),
+    K_XX_COEFF: default_lap_coeffs,
+    K_YY_COEFF: default_lap_coeffs,
+    K_HOMOG_SOLN: lambda x: jnp.zeros_like(x[..., 0]),
+    K_SOURCE: lambda x: 4 * jnp.expand_dims(jnp.ones_like(x[..., 0]), -1),
+    K_PART_SOLN: part_soln_iti_fn,
+    K_PART_SOLN_DUDX: part_soln_iti_dudx_fn,
+    K_PART_SOLN_DUDY: part_soln_iti_dudy_fn,
 }

--- a/tests/test_accuracy/test_nosource_accuracy.py
+++ b/tests/test_accuracy/test_nosource_accuracy.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Dict
 import jax.numpy as jnp
-import pytest
 from hahps._discretization_tree import DiscretizationNode2D
 from hahps._domain import Domain
 from hahps._pdeproblem import PDEProblem
@@ -15,7 +14,6 @@ from hahps.merge._nosource_uniform_2D_ItI import (
 )
 from hahps.up_pass._uniform_2D_ItI import up_pass_uniform_2D_ItI
 from hahps.down_pass._uniform_2D_ItI import down_pass_uniform_2D_ItI
-from hahps._utils import plot_soln_from_cheby_nodes
 
 from .cases import (
     XMIN,
@@ -129,13 +127,13 @@ def check_merge_accuracy_nosource_2D_ItI_uniform_Helmholtz_like(
         expected_soln.shape,
     )
 
-    # Plot the solution
-    plot_soln_from_cheby_nodes(
-        cheby_nodes=domain.interior_points.reshape(-1, 2),
-        corners=None,
-        expected_soln=expected_soln.imag.flatten(),
-        computed_soln=computed_soln.imag.flatten(),
-    )
+    # Plot the solution. This function can be found in src/hahps/_utils.py
+    # plot_soln_from_cheby_nodes(
+    #     cheby_nodes=domain.interior_points.reshape(-1, 2),
+    #     corners=None,
+    #     expected_soln=expected_soln.imag.flatten(),
+    #     computed_soln=computed_soln.imag.flatten(),
+    # )
 
     assert jnp.allclose(
         computed_soln,
@@ -235,6 +233,20 @@ def check_against_standard_2D_ItI_uniform(
     logging.debug("g_tilde_lst len: %s", len(g_tilde_lst))
     logging.debug("g_tilde_lst_nosource len: %s", len(g_tilde_lst_nosource))
     for i in range(len(g_tilde_lst)):
+        logging.debug(
+            "g_tilde_list_nosource[i].shape=%s", g_tilde_lst_nosource[i].shape
+        )
+        logging.debug("g_tilde_list[i].shape=%s", g_tilde_lst[i].shape)
+
+        # for j in range(1):
+        #     g_tilde = g_tilde_lst[i][j]
+        #     g_tilde_nosource = g_tilde_lst_nosource[i][j]
+        #     plt.plot(g_tilde.real, ".-", label=f"Expected real, j={j}")
+        #     plt.plot(
+        #         g_tilde_nosource.real, ".-", label=f"Computed real, j={j}"
+        #     )
+        # plt.legend()
+        # plt.show()
         assert jnp.allclose(
             g_tilde_lst_nosource[i],
             g_tilde_lst[i],
@@ -246,7 +258,7 @@ def check_against_standard_2D_ItI_uniform(
 
 
 class Test_accuracy_2D_ItI_uniform:
-    @pytest.mark.skip
+    # @pytest.mark.skip
     def test_0(self, caplog) -> None:
         caplog.set_level(logging.DEBUG)
 

--- a/tests/test_accuracy/test_nosource_accuracy.py
+++ b/tests/test_accuracy/test_nosource_accuracy.py
@@ -1,16 +1,263 @@
+import logging
+from typing import Dict
+import jax.numpy as jnp
+import pytest
 from hahps._discretization_tree import DiscretizationNode2D
 from hahps._domain import Domain
+from hahps._pdeproblem import PDEProblem
+from hahps.local_solve._uniform_2D_ItI import local_solve_stage_uniform_2D_ItI
+from hahps.local_solve._nosource_uniform_2D_ItI import (
+    nosource_local_solve_stage_uniform_2D_ItI,
+)
+from hahps.merge._uniform_2D_ItI import merge_stage_uniform_2D_ItI
+from hahps.merge._nosource_uniform_2D_ItI import (
+    nosource_merge_stage_uniform_2D_ItI,
+)
+from hahps.up_pass._uniform_2D_ItI import up_pass_uniform_2D_ItI
+from hahps.down_pass._uniform_2D_ItI import down_pass_uniform_2D_ItI
+from hahps._utils import plot_soln_from_cheby_nodes
+
 from .cases import (
     XMIN,
     XMAX,
     YMIN,
     YMAX,
+    ETA,
+    TEST_CASE_HELMHOLTZ_ITI,
+    K_XX_COEFF,
+    K_YY_COEFF,
+    K_SOURCE,
+    K_SOLN,
+    K_DUDX,
+    K_DUDY,
+    K_I_COEFF,
 )
+
+ATOL_NONPOLY = 1e-8
 
 ATOL = 1e-12
 RTOL = 0.0
 
 P = 6
 Q = 4
+
+P_NONPOLY = 16
+Q_NONPOLY = 14
+ROOT_DTN = DiscretizationNode2D(xmin=XMIN, xmax=XMAX, ymin=YMIN, ymax=YMAX)
 ROOT_ITI = DiscretizationNode2D(xmin=XMIN, xmax=XMAX, ymin=YMIN, ymax=YMAX)
+DOMAIN_DTN = Domain(p=P, q=Q, root=ROOT_DTN, L=1)
 DOMAIN_ITI = Domain(p=P, q=Q, root=ROOT_ITI, L=1)
+DOMAIN_ITI_NONPOLY = Domain(p=P_NONPOLY, q=Q_NONPOLY, root=ROOT_ITI, L=2)
+
+
+def check_merge_accuracy_nosource_2D_ItI_uniform_Helmholtz_like(
+    domain: Domain, test_case: Dict
+) -> None:
+    """This is for ItI problems solving an inhomogeneous Helmholtz equation where the
+    solution is specified as one solution, rathern than the sum of homogeneous and particular parts
+    """
+    d_xx_coeffs = test_case[K_XX_COEFF](domain.interior_points)
+    d_yy_coeffs = test_case[K_YY_COEFF](domain.interior_points)
+    i_coeffs = test_case[K_I_COEFF](domain.interior_points)
+    source = test_case[K_SOURCE](domain.interior_points)
+
+    logging.debug(
+        "check_leaf_accuracy_ItI_Helmholtz_like: source shape: %s",
+        source.shape,
+    )
+
+    pde_problem = PDEProblem(
+        domain=domain,
+        D_xx_coefficients=d_xx_coeffs,
+        D_yy_coefficients=d_yy_coeffs,
+        I_coefficients=i_coeffs,
+        use_ItI=True,
+        eta=ETA,
+    )
+
+    ##############################################################
+    # Build the precomputed solution operators
+    Y, T = nosource_local_solve_stage_uniform_2D_ItI(pde_problem=pde_problem)
+    S_lst, D_inv_lst, BD_inv_lst, T = nosource_merge_stage_uniform_2D_ItI(
+        T, domain.L, return_T=True
+    )
+
+    pde_problem.D_inv_lst = D_inv_lst
+    pde_problem.BD_inv_lst = BD_inv_lst
+
+    logging.debug("D_inv_lst shapes: %s", [d_inv.shape for d_inv in D_inv_lst])
+    logging.debug(
+        "BD_inv_lst shapes: %s", [bd_inv.shape for bd_inv in BD_inv_lst]
+    )
+
+    #############################################################
+    # Upward pass
+    v, g_tilde_lst = up_pass_uniform_2D_ItI(
+        source=source, pde_problem=pde_problem
+    )
+
+    ##############################################################
+    # Compute the incoming impedance data
+
+    # Assemble incoming impedance data
+    q = domain.boundary_points.shape[0] // 4
+    boundary_u = test_case[K_SOLN](domain.boundary_points)
+    boundary_u_normals = jnp.concatenate(
+        [
+            -1 * test_case[K_DUDY](domain.boundary_points[:q]),
+            test_case[K_DUDX](domain.boundary_points[q : 2 * q]),
+            test_case[K_DUDY](domain.boundary_points[2 * q : 3 * q]),
+            -1 * test_case[K_DUDX](domain.boundary_points[3 * q :]),
+        ]
+    )
+    incoming_imp_data = boundary_u_normals + 1j * pde_problem.eta * boundary_u
+
+    ##############################################################
+    # Check the accuracy of the homogeneous solution
+    # Construct computed homogeneous solution
+
+    computed_soln = down_pass_uniform_2D_ItI(
+        incoming_imp_data, S_lst, g_tilde_lst, Y, v
+    )
+    logging.debug(
+        "check_leaf_accuracy_ItI_Helmholtz_like: computed_soln shape: %s",
+        computed_soln.shape,
+    )
+    expected_soln = test_case[K_SOLN](domain.interior_points)
+    logging.debug(
+        "check_leaf_accuracy_ItI_Helmholtz_like: expected_soln shape: %s",
+        expected_soln.shape,
+    )
+
+    # Plot the solution
+    plot_soln_from_cheby_nodes(
+        cheby_nodes=domain.interior_points.reshape(-1, 2),
+        corners=None,
+        expected_soln=expected_soln.imag.flatten(),
+        computed_soln=computed_soln.imag.flatten(),
+    )
+
+    assert jnp.allclose(
+        computed_soln,
+        expected_soln,
+        atol=ATOL_NONPOLY,
+        rtol=RTOL,
+    )
+
+
+ATOL_DIFFS = 1e-8
+RTOL_DIFFS = 0.0
+
+
+def check_against_standard_2D_ItI_uniform(
+    domain: Domain, test_case: Dict
+) -> None:
+    d_xx_coeffs = test_case[K_XX_COEFF](domain.interior_points)
+    d_yy_coeffs = test_case[K_YY_COEFF](domain.interior_points)
+    i_coeffs = test_case[K_I_COEFF](domain.interior_points)
+    source = test_case[K_SOURCE](domain.interior_points)
+
+    pde_problem_nosource = PDEProblem(
+        domain=domain,
+        D_xx_coefficients=d_xx_coeffs,
+        D_yy_coefficients=d_yy_coeffs,
+        I_coefficients=i_coeffs,
+        use_ItI=True,
+        eta=ETA,
+    )
+
+    pde_problem_source = PDEProblem(
+        domain=domain,
+        D_xx_coefficients=d_xx_coeffs,
+        D_yy_coefficients=d_yy_coeffs,
+        I_coefficients=i_coeffs,
+        source=source,
+        use_ItI=True,
+        eta=ETA,
+    )
+
+    ##############################################################
+    # Check outputs of local solve stage
+    Y_nosource, T_nosource = nosource_local_solve_stage_uniform_2D_ItI(
+        pde_problem=pde_problem_nosource
+    )
+    Y, T, v, h = local_solve_stage_uniform_2D_ItI(
+        pde_problem=pde_problem_source
+    )
+
+    assert jnp.allclose(Y_nosource, Y, atol=ATOL_DIFFS, rtol=RTOL_DIFFS), (
+        f"Max difference = {jnp.max(jnp.abs(Y_nosource - Y))}"
+    )
+    assert jnp.allclose(T_nosource, T, atol=ATOL_DIFFS, rtol=RTOL_DIFFS), (
+        f"Max difference = {jnp.max(jnp.abs(T_nosource - T))}"
+    )
+
+    ##############################################################
+    # Check outputs of merge stage
+    (
+        S_lst_nosource,
+        D_inv_lst_nosource,
+        BD_inv_lst_nosource,
+        T_last_nosource,
+    ) = nosource_merge_stage_uniform_2D_ItI(
+        T_nosource, domain.L, return_T=True
+    )
+    pde_problem_nosource.D_inv_lst = D_inv_lst_nosource
+    pde_problem_nosource.BD_inv_lst = BD_inv_lst_nosource
+    S_lst, g_tilde_lst, T_last_source = merge_stage_uniform_2D_ItI(
+        T, h, domain.L, return_T=True
+    )
+
+    for i in range(len(S_lst)):
+        assert jnp.allclose(
+            S_lst_nosource[i], S_lst[i], atol=ATOL_DIFFS, rtol=RTOL_DIFFS
+        ), (
+            f"Max difference in S_lst[{i}] = {jnp.max(jnp.abs(S_lst_nosource[i] - S_lst[i]))}"
+        )
+
+    # Check top-level ItI matrices
+    assert jnp.allclose(
+        T_last_nosource, T_last_source, atol=ATOL_DIFFS, rtol=RTOL_DIFFS
+    ), (
+        f"Max difference in T_last_nosource and T_last_source = {jnp.max(jnp.abs(T_last_nosource - T_last_source))}"
+    )
+
+    ##################################################################
+    # Check outputs of upward pass
+    v_nosource, g_tilde_lst_nosource = up_pass_uniform_2D_ItI(
+        source=source, pde_problem=pde_problem_nosource
+    )
+
+    # Check v
+    assert jnp.allclose(v_nosource, v, atol=ATOL_DIFFS, rtol=RTOL_DIFFS), (
+        f"Max difference in v = {jnp.max(jnp.abs(v_nosource - v))}"
+    )
+    logging.debug("g_tilde_lst len: %s", len(g_tilde_lst))
+    logging.debug("g_tilde_lst_nosource len: %s", len(g_tilde_lst_nosource))
+    for i in range(len(g_tilde_lst)):
+        assert jnp.allclose(
+            g_tilde_lst_nosource[i],
+            g_tilde_lst[i],
+            atol=ATOL_DIFFS,
+            rtol=RTOL_DIFFS,
+        ), (
+            f"Max difference in g_tilde_lst_nosource[{i}] = {jnp.max(jnp.abs(g_tilde_lst_nosource[i] - g_tilde_lst[i]))}"
+        )
+
+
+class Test_accuracy_2D_ItI_uniform:
+    @pytest.mark.skip
+    def test_0(self, caplog) -> None:
+        caplog.set_level(logging.DEBUG)
+
+        check_merge_accuracy_nosource_2D_ItI_uniform_Helmholtz_like(
+            DOMAIN_ITI_NONPOLY, TEST_CASE_HELMHOLTZ_ITI
+        )
+
+
+class Test_against_standard_version:
+    def test_0(self, caplog) -> None:
+        caplog.set_level(logging.DEBUG)
+        check_against_standard_2D_ItI_uniform(
+            DOMAIN_ITI_NONPOLY, TEST_CASE_HELMHOLTZ_ITI
+        )

--- a/tests/test_accuracy/test_nosource_accuracy.py
+++ b/tests/test_accuracy/test_nosource_accuracy.py
@@ -1,0 +1,16 @@
+from hahps._discretization_tree import DiscretizationNode2D
+from hahps._domain import Domain
+from .cases import (
+    XMIN,
+    XMAX,
+    YMIN,
+    YMAX,
+)
+
+ATOL = 1e-12
+RTOL = 0.0
+
+P = 6
+Q = 4
+ROOT_ITI = DiscretizationNode2D(xmin=XMIN, xmax=XMAX, ymin=YMIN, ymax=YMAX)
+DOMAIN_ITI = Domain(p=P, q=Q, root=ROOT_ITI, L=1)

--- a/tests/test_accuracy/test_single_merge_accuracy.py
+++ b/tests/test_accuracy/test_single_merge_accuracy.py
@@ -12,6 +12,8 @@ from hahps.merge._uniform_2D_DtN import merge_stage_uniform_2D_DtN
 from hahps.merge._uniform_2D_ItI import merge_stage_uniform_2D_ItI
 from hahps.down_pass._uniform_2D_DtN import down_pass_uniform_2D_DtN
 from hahps.down_pass._uniform_2D_ItI import down_pass_uniform_2D_ItI
+# from hahps._utils import plot_soln_from_cheby_nodes
+
 from .cases import (
     XMIN,
     XMAX,
@@ -20,6 +22,7 @@ from .cases import (
     ETA,
     TEST_CASE_POLY_PART_HOMOG,
     TEST_CASE_POLY_ZERO_SOURCE,
+    TEST_CASE_HELMHOLTZ_ITI,
     K_DIRICHLET,
     K_XX_COEFF,
     K_YY_COEFF,
@@ -28,17 +31,27 @@ from .cases import (
     K_DIRICHLET_DUDY,
     K_PART_SOLN,
     K_HOMOG_SOLN,
+    K_SOLN,
+    K_DUDX,
+    K_DUDY,
+    K_I_COEFF,
 )
+
+ATOL_NONPOLY = 1e-8
 
 ATOL = 1e-12
 RTOL = 0.0
 
 P = 6
 Q = 4
+
+P_NONPOLY = 16
+Q_NONPOLY = 14
 ROOT_DTN = DiscretizationNode2D(xmin=XMIN, xmax=XMAX, ymin=YMIN, ymax=YMAX)
 ROOT_ITI = DiscretizationNode2D(xmin=XMIN, xmax=XMAX, ymin=YMIN, ymax=YMAX)
 DOMAIN_DTN = Domain(p=P, q=Q, root=ROOT_DTN, L=1)
 DOMAIN_ITI = Domain(p=P, q=Q, root=ROOT_ITI, L=1)
+DOMAIN_ITI_NONPOLY = Domain(p=P_NONPOLY, q=Q_NONPOLY, root=ROOT_ITI, L=1)
 
 
 def check_merge_accuracy_2D_DtN_uniform(
@@ -268,6 +281,88 @@ def check_merge_accuracy_2D_ItI_uniform(
     assert jnp.allclose(computed_soln, expected_soln, atol=ATOL, rtol=RTOL)
 
 
+def check_merge_accuracy_2D_ItI_uniform_Helmholtz_like(
+    domain: Domain, test_case: Dict
+) -> None:
+    """This is for ItI problems solving an inhomogeneous Helmholtz equation where the
+    solution is specified as one solution, rathern than the sum of homogeneous and particular parts
+    """
+    d_xx_coeffs = test_case[K_XX_COEFF](domain.interior_points)
+    d_yy_coeffs = test_case[K_YY_COEFF](domain.interior_points)
+    i_coeffs = test_case[K_I_COEFF](domain.interior_points)
+    source = test_case[K_SOURCE](domain.interior_points)
+
+    logging.debug(
+        "check_leaf_accuracy_ItI_Helmholtz_like: source shape: %s",
+        source.shape,
+    )
+
+    pde_problem = PDEProblem(
+        domain=domain,
+        source=source,
+        D_xx_coefficients=d_xx_coeffs,
+        D_yy_coefficients=d_yy_coeffs,
+        I_coefficients=i_coeffs,
+        use_ItI=True,
+        eta=ETA,
+    )
+
+    ##############################################################
+    # Solve the local problem
+    Y, T, v, h = local_solve_stage_uniform_2D_ItI(pde_problem=pde_problem)
+    S_lst, g_tilde_lst, T_last = merge_stage_uniform_2D_ItI(
+        T, h, domain.L - 1, return_T=True
+    )
+
+    ##############################################################
+    # Compute the incoming impedance data
+
+    # Assemble incoming impedance data
+    q = domain.boundary_points.shape[0] // 4
+    boundary_u = test_case[K_SOLN](domain.boundary_points)
+    boundary_u_normals = jnp.concatenate(
+        [
+            -1 * test_case[K_DUDY](domain.boundary_points[:q]),
+            test_case[K_DUDX](domain.boundary_points[q : 2 * q]),
+            test_case[K_DUDY](domain.boundary_points[2 * q : 3 * q]),
+            -1 * test_case[K_DUDX](domain.boundary_points[3 * q :]),
+        ]
+    )
+    incoming_imp_data = boundary_u_normals + 1j * pde_problem.eta * boundary_u
+
+    ##############################################################
+    # Check the accuracy of the homogeneous solution
+    # Construct computed homogeneous solution
+
+    computed_soln = down_pass_uniform_2D_ItI(
+        incoming_imp_data, S_lst, g_tilde_lst, Y, v
+    )
+    logging.debug(
+        "check_leaf_accuracy_ItI_Helmholtz_like: computed_soln shape: %s",
+        computed_soln.shape,
+    )
+    expected_soln = test_case[K_SOLN](domain.interior_points)
+    logging.debug(
+        "check_leaf_accuracy_ItI_Helmholtz_like: expected_soln shape: %s",
+        expected_soln.shape,
+    )
+
+    # Plot the solution
+    # plot_soln_from_cheby_nodes(
+    #     cheby_nodes=domain.interior_points.reshape(-1, 2),
+    #     corners=None,
+    #     expected_soln=expected_soln.imag.flatten(),
+    #     computed_soln=computed_soln.imag.flatten(),
+    # )
+
+    assert jnp.allclose(
+        computed_soln,
+        expected_soln,
+        atol=ATOL_NONPOLY,
+        rtol=RTOL,
+    )
+
+
 class Test_accuracy_single_merge_2D_DtN_uniform:
     def test_0(self, caplog) -> None:
         """Polynomial data with zero source term."""
@@ -292,6 +387,15 @@ class Test_accuracy_single_merge_2D_ItI_uniform:
 
         check_merge_accuracy_2D_ItI_uniform(
             DOMAIN_ITI, TEST_CASE_POLY_ZERO_SOURCE
+        )
+        jax.clear_caches()
+
+    def test_1(self, caplog) -> None:
+        """Polynomial data with non-zero source term."""
+        caplog.set_level(logging.DEBUG)
+
+        check_merge_accuracy_2D_ItI_uniform_Helmholtz_like(
+            DOMAIN_ITI_NONPOLY, TEST_CASE_HELMHOLTZ_ITI
         )
         jax.clear_caches()
 

--- a/tests/test_build_solver.py
+++ b/tests/test_build_solver.py
@@ -149,8 +149,8 @@ class Test_build_solver:
             "Here are S_lst shapes: %s", [s.shape for s in pde_problem.S_lst]
         )
 
-        assert pde_problem.S_lst[-1].shape == (1, n_bdry // 2, n_bdry)
-        assert pde_problem.g_tilde_lst[-1].shape == (1, n_bdry // 2)
+        assert pde_problem.S_lst[-1].shape == (n_bdry // 2, n_bdry)
+        assert pde_problem.g_tilde_lst[-1].shape == (n_bdry // 2,)
 
     def test_3(self, caplog) -> None:
         """Adaptive 2D DtN"""
@@ -307,6 +307,48 @@ class Test_build_solver:
             D_xx_coefficients=d_xx_coeffs,
             D_yy_coefficients=d_yy_coeffs,
             source=source,
+            use_ItI=True,
+            eta=1.0,
+        )
+
+        # Build the solver
+        T = build_solver(pde_problem, return_top_T=True)
+
+        n_bdry = domain.boundary_points.shape[0]
+        assert T.shape == (n_bdry, n_bdry)
+
+        assert len(pde_problem.S_lst) == L
+        assert len(pde_problem.g_tilde_lst) == L
+
+        # g_tilde has shape n_bdry in the ItI case.
+        assert pde_problem.S_lst[-1].shape == (1, n_bdry, n_bdry)
+        assert pde_problem.g_tilde_lst[-1].shape == (1, n_bdry)
+
+    def test_7(self, caplog) -> None:
+        """Uniform 2D ItI with no source"""
+        caplog.set_level(logging.DEBUG)
+        p = 6
+        q = 4
+        L = 2
+
+        # Create a uniform 2D domain
+        root = DiscretizationNode2D(xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0)
+
+        domain = Domain(p=p, q=q, root=root, L=L)
+
+        d_xx_coeffs = jnp.array(
+            np.random.normal(size=domain.interior_points[..., 0].shape)
+        )
+
+        d_yy_coeffs = jnp.array(
+            np.random.normal(size=domain.interior_points[..., 0].shape)
+        )
+
+        # Create a PDEProblem instance
+        pde_problem = PDEProblem(
+            domain=domain,
+            D_xx_coefficients=d_xx_coeffs,
+            D_yy_coefficients=d_yy_coeffs,
             use_ItI=True,
             eta=1.0,
         )

--- a/tests/test_merge/test_merge_nosource_uniform_2D_ItI.py
+++ b/tests/test_merge/test_merge_nosource_uniform_2D_ItI.py
@@ -40,7 +40,7 @@ class Test_nosource_merge_stage_uniform_2D_ItI:
             eta=eta,
         )
 
-        T_arr, Y_arr = nosource_local_solve_stage_uniform_2D_ItI(pde_problem=t)
+        Y_arr, T_arr = nosource_local_solve_stage_uniform_2D_ItI(pde_problem=t)
 
         assert Y_arr.shape == (n_leaves, p**2, 4 * q)
         # n_leaves, n_bdry, _ = DtN_arr.shape

--- a/tests/test_merge/test_merge_nosource_uniform_2D_ItI.py
+++ b/tests/test_merge/test_merge_nosource_uniform_2D_ItI.py
@@ -1,0 +1,103 @@
+import numpy as np
+
+from hahps.merge._nosource_uniform_2D_ItI import (
+    nosource_merge_stage_uniform_2D_ItI,
+    _nosource_uniform_quad_merge_ItI,
+)
+
+from hahps.local_solve._nosource_uniform_2D_ItI import (
+    nosource_local_solve_stage_uniform_2D_ItI,
+)
+from hahps._discretization_tree import DiscretizationNode2D
+from hahps._domain import Domain
+from hahps._pdeproblem import PDEProblem
+
+
+class Test_nosource_merge_stage_uniform_2D_ItI:
+    def test_0(self) -> None:
+        """Tests the function returns without error."""
+        p = 6
+        q = 4
+        l = 3
+        eta = 4.0
+
+        root = DiscretizationNode2D(
+            xmin=0.0,
+            xmax=1.0,
+            ymin=0.0,
+            ymax=1.0,
+        )
+        domain = Domain(p=p, q=q, root=root, L=l)
+        n_leaves = 4**l
+
+        d_xx_coeffs = np.random.normal(size=(n_leaves, p**2))
+        print("test_0: d_xx_coeffs = ", d_xx_coeffs.shape)
+
+        t = PDEProblem(
+            domain=domain,
+            D_xx_coefficients=d_xx_coeffs,
+            use_ItI=True,
+            eta=eta,
+        )
+
+        T_arr, Y_arr = nosource_local_solve_stage_uniform_2D_ItI(pde_problem=t)
+
+        assert Y_arr.shape == (n_leaves, p**2, 4 * q)
+        # n_leaves, n_bdry, _ = DtN_arr.shape
+        # DtN_arr = DtN_arr.reshape((int(n_leaves / 2), 2, n_bdry, n_bdry))
+        # v_prime_arr = v_prime_arr.reshape((int(n_leaves / 2), 2, 4 * t.q))
+
+        S_arr_lst, D_inv_lst, BD_inv_lst = nosource_merge_stage_uniform_2D_ItI(
+            T_arr=T_arr, l=l
+        )
+        print(
+            "test_0: S_arr_lst shapes = ", [S_arr.shape for S_arr in S_arr_lst]
+        )
+
+        assert len(S_arr_lst) == l
+        assert len(D_inv_lst) == l
+        assert len(BD_inv_lst) == l
+
+        for i in range(l):
+            print("test_0: i=", i)
+            print("test_0: S_arr_lst[i].shape = ", S_arr_lst[i].shape)
+            # print("test_0: f_arr_lst[i].shape = ", f_arr_lst[i].shape)
+            assert S_arr_lst[i].shape[-2] == D_inv_lst[i].shape[-2]
+
+        # Check the shapes of the bottom-level output arrays
+        n_quads = (n_leaves // 4) // 4
+        assert S_arr_lst[0].shape == (4 * n_quads, 8 * q, 8 * q)
+        # assert f_arr_lst[0].shape == (4 * n_quads, 8 * q)
+
+        # Check the shapes of the middle-level output arrays.
+        n_bdry = 16 * q
+        n_interface = 16 * q
+        assert S_arr_lst[1].shape == (4, n_interface, n_bdry)
+        # assert f_arr_lst[1].shape == (4, n_interface)
+
+        # Check the shapes of the top-level output arrays.
+        n_root_bdry = t.domain.boundary_points.shape[0]
+        n_root_interface = n_root_bdry
+        assert S_arr_lst[2].shape == (1, n_root_interface, n_root_bdry)
+        # assert f_arr_lst[2].shape == (1, n_root_interface)
+
+
+class Test__uniform_quad_merge_ItI:
+    def test_0(self) -> None:
+        n_bdry = 28
+        n_bdry_int = n_bdry // 4
+        n_bdry_ext = 2 * (n_bdry // 4)
+        T_a = np.random.normal(size=(n_bdry, n_bdry))
+        T_b = np.random.normal(size=(n_bdry, n_bdry))
+        T_c = np.random.normal(size=(n_bdry, n_bdry))
+        T_d = np.random.normal(size=(n_bdry, n_bdry))
+
+        print("test_0: T_a shape: ", T_a.shape)
+        S, R, D_inv, BD_inv = _nosource_uniform_quad_merge_ItI(
+            T_a, T_b, T_c, T_d
+        )
+
+        assert S.shape == (8 * n_bdry_int, 4 * n_bdry_ext)
+        assert R.shape == (4 * n_bdry_ext, 4 * n_bdry_ext)
+        assert D_inv.shape == (8 * n_bdry_int, 8 * n_bdry_int)
+        assert BD_inv.shape == (4 * n_bdry_ext, 8 * n_bdry_int)

--- a/tests/test_pdeproblem.py
+++ b/tests/test_pdeproblem.py
@@ -111,6 +111,40 @@ class Test_PDEProblem_init:
         assert pde_problem.P.shape == (p**3 - (p - 2) ** 3, 6 * q**2)
         assert pde_problem.Q.shape == (6 * q**2, p**3)
 
+    def test_3(self) -> None:
+        """2D ItI Initialization w/out source"""
+
+        # Create a 2D uniform domain
+        xmin = 0.0
+        xmax = 1.0
+        ymin = 0.0
+        ymax = 1.0
+        p = 6
+        q = 4
+        L = 2
+        root = DiscretizationNode2D(
+            xmin=xmin,
+            xmax=xmax,
+            ymin=ymin,
+            ymax=ymax,
+        )
+        domain = Domain(p=p, q=q, root=root, L=L)
+
+        D_xx_coefficients = jnp.zeros_like(domain.interior_points[..., 0])
+
+        pde_problem = PDEProblem(
+            domain=domain,
+            D_xx_coefficients=D_xx_coefficients,
+            use_ItI=True,
+            eta=1.0,
+        )
+
+        # Check the shape of the precomputed operators.
+        assert pde_problem.D_x.shape == (p**2, p**2)
+        assert pde_problem.P.shape == (4 * (p - 1), 4 * q)
+        assert pde_problem.G.shape == (4 * (p - 1), p**2)
+        assert pde_problem.QH.shape == (4 * q, p**2)
+
 
 class Test__get_PDEProblem_chunk:
     def test_0(self) -> None:

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -269,3 +269,61 @@ class Test_solve:
 
         solns = solve(pde_problem, bdry_data_lst)
         assert solns.shape == (domain.interior_points[..., 0].shape)
+
+    def test_5(self, caplog) -> None:
+        """Uniform 2D ItI with up and down passes"""
+        caplog.set_level(logging.DEBUG)
+        p = 6
+        q = 4
+        L = 2
+
+        # Create a uniform 2D domain
+        root = DiscretizationNode2D(xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0)
+
+        domain = Domain(p=p, q=q, root=root, L=L)
+
+        d_xx_coeffs = jnp.array(
+            np.random.normal(size=domain.interior_points[..., 0].shape)
+        )
+
+        d_yy_coeffs = jnp.array(
+            np.random.normal(size=domain.interior_points[..., 0].shape)
+        )
+
+        # Create a PDEProblem instance
+        pde_problem = PDEProblem(
+            domain=domain,
+            D_xx_coefficients=d_xx_coeffs,
+            D_yy_coefficients=d_yy_coeffs,
+            use_ItI=True,
+            eta=1.0,
+        )
+
+        # Build the solver
+        T = build_solver(pde_problem, return_top_T=True)
+
+        n_bdry = domain.boundary_points.shape[0]
+        assert T.shape == (n_bdry, n_bdry)
+
+        assert len(pde_problem.S_lst) == L
+
+        # g_tilde has shape n_bdry in the ItI case.
+        assert pde_problem.S_lst[-1].shape == (1, n_bdry, n_bdry)
+        # Solve the problem
+        bdry_data = jnp.array(np.random.normal(size=n_bdry))
+
+        source = jnp.array(
+            np.random.normal(size=domain.interior_points[..., 0].shape)
+        )
+
+        solns = solve(pde_problem, bdry_data, source=source)
+
+        assert solns.shape == (domain.interior_points[..., 0].shape)
+
+        source2 = jnp.array(
+            np.random.normal(size=domain.interior_points[..., 0].shape)
+        )
+        bdry_data2 = jnp.array(np.random.normal(size=n_bdry))
+
+        solns2 = solve(pde_problem, bdry_data2, source=source2)
+        assert solns2.shape == (domain.interior_points[..., 0].shape)

--- a/tests/test_up_pass/test_up_pass_uniform_2D_ItI.py
+++ b/tests/test_up_pass/test_up_pass_uniform_2D_ItI.py
@@ -1,0 +1,93 @@
+import jax.numpy as jnp
+
+import numpy as np
+from hahps.up_pass._uniform_2D_ItI import (
+    up_pass_uniform_2D_ItI,
+    assemble_boundary_data,
+)
+from hahps._discretization_tree import DiscretizationNode2D
+from hahps._domain import Domain
+from hahps._pdeproblem import PDEProblem
+from hahps.merge._nosource_uniform_2D_ItI import (
+    nosource_merge_stage_uniform_2D_ItI,
+)
+
+from hahps.local_solve._nosource_uniform_2D_ItI import (
+    nosource_local_solve_stage_uniform_2D_ItI,
+)
+import logging
+
+
+class Test_assemble_boundary_data:
+    def test_0(self, caplog) -> None:
+        """Tests return shapes are correct."""
+
+        nside = 3
+        h_in = jnp.zeros((4, 4 * nside))
+        D_inv = jnp.zeros((8 * nside, 8 * nside))
+        BD_inv = jnp.zeros((8 * nside, 8 * nside))
+
+        h, g_tilde = assemble_boundary_data(h_in, D_inv, BD_inv)
+        assert h.shape == (8 * nside,)
+        assert g_tilde.shape == (8 * nside,)
+
+
+class Test_up_pass_uniform_2D_ItI:
+    def test_0(self, caplog) -> None:
+        """Tests to make sure things run without error."""
+        caplog.set_level(logging.DEBUG)
+        p = 6
+        q = 4
+        l = 3
+        eta = 4.0
+
+        root = DiscretizationNode2D(
+            xmin=0.0,
+            xmax=1.0,
+            ymin=0.0,
+            ymax=1.0,
+        )
+        domain = Domain(p=p, q=q, root=root, L=l)
+        n_leaves = 4**l
+
+        d_xx_coeffs = np.random.normal(size=(n_leaves, p**2))
+        print("test_0: d_xx_coeffs = ", d_xx_coeffs.shape)
+
+        t = PDEProblem(
+            domain=domain,
+            D_xx_coefficients=d_xx_coeffs,
+            use_ItI=True,
+            eta=eta,
+        )
+
+        T_arr, Y_arr = nosource_local_solve_stage_uniform_2D_ItI(pde_problem=t)
+
+        assert Y_arr.shape == (n_leaves, p**2, 4 * q)
+        # n_leaves, n_bdry, _ = DtN_arr.shape
+        # DtN_arr = DtN_arr.reshape((int(n_leaves / 2), 2, n_bdry, n_bdry))
+        # v_prime_arr = v_prime_arr.reshape((int(n_leaves / 2), 2, 4 * t.q))
+
+        S_arr_lst, D_inv_lst, BD_inv_lst = nosource_merge_stage_uniform_2D_ItI(
+            T_arr=T_arr, l=l
+        )
+
+        t.D_inv_lst = D_inv_lst
+        t.BD_inv_lst = BD_inv_lst
+
+        logging.debug(
+            "test_0: D_inv_lst shapes = %s", [s.shape for s in D_inv_lst]
+        )
+        logging.debug(
+            "test_0: BD_inv_lst shapes = %s", [s.shape for s in BD_inv_lst]
+        )
+
+        source = jnp.ones_like(domain.interior_points[..., 0])
+
+        # Do the upward pass
+        v, g_tilde_lst = up_pass_uniform_2D_ItI(
+            source=source,
+            pde_problem=t,
+        )
+
+        assert v.shape == (n_leaves, p**2)
+        assert len(g_tilde_lst) == l


### PR DESCRIPTION
This update adds functionality to build the fast direct solver for 2D ItI problems without a source term. The source term can be specified later; in this case the particular solution is constructed through an upward pass of the tree. 

This implements the basic functionality but there are some things left to do:
 * Implement this functionality for other problems, like uniform 2D and 3D DtN problems.
 * Currently, the upward pass re-does the local solve stage because I am worried about the memory complexity of storing all of the inverted leaf-level differential operators. This decision hasn't been evaluated for performance or anything and should be studied. If leaf-level recomputation is indeed necessary, I should implement a new version of the leaf solve stage which just does a linear solve using the differential operators to get the particular solution.
 * This update exposes a new function `up_pass.up_pass_2D_uniform_ItI` and it should be included in the documentation. Also, I need to decide whether to include the `nosource_*` functions should also be exposed in the public API.