### PR TITLE
Allow 2D uniform problems to be built before the source is specified.

### DIFF
--- a/docs/solution_methods.rst
+++ b/docs/solution_methods.rst
@@ -49,11 +49,13 @@ Merge Stage
 .. automodule:: hahps.merge
    :members:
 
-
-
 Downward Pass
 ----------------
 
-
 .. automodule:: hahps.down_pass
+   :members:
+
+Upward Pass 
+----------------
+.. automodule:: hahps.up_pass
    :members:

--- a/examples/wave_scattering_compute_reference_soln.py
+++ b/examples/wave_scattering_compute_reference_soln.py
@@ -189,7 +189,7 @@ def main(args: argparse.Namespace) -> None:
     plot_field_for_wave_scattering_experiment(
         q_vals,
         target_pts,
-        title="q",
+        # title="q",
         save_fp=os.path.join(output_dir, "q.pdf"),
     )
 
@@ -198,7 +198,7 @@ def main(args: argparse.Namespace) -> None:
         jnp.real(uscat),
         target_pts,
         use_bwr_cmap=True,
-        title="uscat real",
+        # title="uscat real",
         save_fp=os.path.join(output_dir, "uscat_real.pdf"),
     )
 
@@ -207,7 +207,7 @@ def main(args: argparse.Namespace) -> None:
         jnp.imag(uscat),
         target_pts,
         use_bwr_cmap=True,
-        title="uscat imag",
+        # title="uscat imag",
         save_fp=os.path.join(output_dir, "uscat_imag.pdf"),
     )
 
@@ -217,7 +217,7 @@ def main(args: argparse.Namespace) -> None:
         target_pts,
         use_bwr_cmap=False,
         cmap_str="hot",
-        title="uscat abs",
+        # title="uscat abs",
         save_fp=os.path.join(output_dir, "uscat_abs.pdf"),
     )
 
@@ -233,7 +233,7 @@ def main(args: argparse.Namespace) -> None:
             jnp.real(utot),
             target_pts,
             use_bwr_cmap=True,
-            title="utot real",
+            # title="utot real",
             save_fp=os.path.join(output_dir, "utot_real.pdf"),
         )
         # plot abs of utot
@@ -242,7 +242,7 @@ def main(args: argparse.Namespace) -> None:
             target_pts,
             use_bwr_cmap=False,
             cmap_str="hot",
-            title="utot abs",
+            # title="utot abs",
             save_fp=os.path.join(output_dir, "utot_abs.pdf"),
         )
 

--- a/src/hahps/_pdeproblem.py
+++ b/src/hahps/_pdeproblem.py
@@ -44,9 +44,6 @@ class PDEProblem:
         self.domain: Domain = domain  #: The domain, which contains information about the discretization.
 
         # Input validation
-        # If it's not an ItI problem, we need to check the source term exists
-        if not use_ItI and source is None:
-            raise ValueError("Source must be specified for non-ItI problems.")
 
         # 2D problems shouldn't specify D_z_coefficients
         if isinstance(domain.root, DiscretizationNode3D):
@@ -77,6 +74,13 @@ class PDEProblem:
             raise ValueError(
                 "ItI merges are only supported for uniform 2D problems."
             )
+
+        # If it's not a uniform 2D problem, the source must be specified
+        if source is None:
+            if not bool_2D or not domain.bool_uniform:
+                raise ValueError(
+                    "Source must be specified for non-uniform or 3D problems."
+                )
 
         # Check input shapes are OK
         check_input_shapes(

--- a/src/hahps/_solve.py
+++ b/src/hahps/_solve.py
@@ -8,12 +8,15 @@ from ._device_config import (
     DEVICE_ARR,
 )
 
-from .down_pass._adaptive_2D_DtN import down_pass_adaptive_2D_DtN
-from .down_pass._adaptive_3D_DtN import down_pass_adaptive_3D_DtN
-from .down_pass._uniform_2D_DtN import down_pass_uniform_2D_DtN
-from .down_pass._uniform_2D_ItI import down_pass_uniform_2D_ItI
-from .down_pass._uniform_3D_DtN import down_pass_uniform_3D_DtN
-from .up_pass._uniform_2D_ItI import up_pass_uniform_2D_ItI
+from .down_pass import (
+    down_pass_uniform_2D_ItI,
+    down_pass_uniform_2D_DtN,
+    down_pass_uniform_3D_DtN,
+    down_pass_adaptive_2D_DtN,
+    down_pass_adaptive_3D_DtN,
+)
+
+from .up_pass import up_pass_uniform_2D_ItI, up_pass_uniform_2D_DtN
 
 
 def solve(
@@ -27,14 +30,14 @@ def solve(
     This function performs the downward pass of the HPS algorithm, after the solution operators have
     been formed by a call to :func:`hahps.build_solver`.
 
-    If the problem is a 2D uniform ItI problem, the source term can be specified here. For other problems, the source term must be specified at the time the solver is built.
+    If the problem is a 2D uniform problem, the source term can be specified here. For other problems, the source term must be specified at the time the solver is built.
 
 
     Args:
-        pde_problem (PDEProblem): Specifies the differential operator, source, domain, and precomputed interpolation and differentiation matrices. Also contains all of the solution operators computed by hahps.build_solver().
+        pde_problem (PDEProblem): Specifies the differential operator, source, domain, and precomputed interpolation and differentiation matrices. Also contains all of the solution operators computed by :func:`hahps.build_solver`.
 
 
-        boundary_data (jax.Array | List[jax.Array]): This specifies the data on the boundary of the domain that will be propagated down to the interior of the leaves. If using an adaptive discretization, this must be specified as a list of arrays, one for each side or face of the root boundary. This list can be specified using the Domain.get_adaptive_boundary_data_lst() utility. For uniform discretizations, this argument can be a jax.Array of shape (n_bdry,) or a list.
+        boundary_data (jax.Array | List[jax.Array]): This specifies the data on the boundary of the domain that will be propagated down to the interior of the leaves. If using an adaptive discretization, this must be specified as a list of arrays, one for each side or face of the root boundary. This list can be specified using the :func:`Domain.get_adaptive_boundary_data_lst` utility. For uniform discretizations, this argument can be a jax.Array of shape (n_bdry,) or a list.
 
         source (jax.Array): The source term for the PDE. Currently, this can only be specified for 2D uniform ItI problems. For other versions, the source must be specified at the time the solver is built.
 
@@ -47,7 +50,10 @@ def solve(
     """
     if source is not None:
         # Check that we're dealing with a 2D uniform ItI problem
-        if not pde_problem.domain.bool_2D or not pde_problem.use_ItI:
+        if (
+            not pde_problem.domain.bool_2D
+            or not pde_problem.domain.bool_uniform
+        ):
             raise ValueError(
                 "Source can only be specified for 2D uniform ItI problems. For other problems, the source must be specified at the time the solver is built."
             )
@@ -117,8 +123,19 @@ def _up_then_down_pass(
     compute_device: jax.Device,
     host_device: jax.Device,
 ) -> jax.Array:
+    # Figure out if ItI or DtN is being used
+    if pde_problem.use_ItI:
+        # If using ItI, we need to compute the g_tilde_lst
+        # and v_arr in the upward pass.
+        up_pass_fn = up_pass_uniform_2D_ItI
+        down_pass_fn = down_pass_uniform_2D_ItI
+    else:
+        # If using DtN, we can just use the precomputed g_tilde_lst and v_arr.
+        up_pass_fn = up_pass_uniform_2D_DtN
+        down_pass_fn = down_pass_uniform_2D_DtN
+
     # First, do the upward pass
-    v, g_tilde_lst = up_pass_uniform_2D_ItI(
+    v, g_tilde_lst = up_pass_fn(
         pde_problem=pde_problem,
         source=source,
         device=compute_device,
@@ -126,8 +143,8 @@ def _up_then_down_pass(
     )
 
     # Now, do the downward pass
-    solns = down_pass_uniform_2D_ItI(
-        boundary_imp_data=boundary_data,
+    solns = down_pass_fn(
+        boundary_data=boundary_data,
         S_lst=pde_problem.S_lst,
         g_tilde_lst=g_tilde_lst,
         Y_arr=pde_problem.Y,

--- a/src/hahps/down_pass/_uniform_2D_DtN.py
+++ b/src/hahps/down_pass/_uniform_2D_DtN.py
@@ -1,7 +1,6 @@
 import jax
 import jax.numpy as jnp
 from typing import List
-
 from .._device_config import HOST_DEVICE, DEVICE_ARR
 
 

--- a/src/hahps/down_pass/_uniform_2D_ItI.py
+++ b/src/hahps/down_pass/_uniform_2D_ItI.py
@@ -8,7 +8,7 @@ from .._device_config import HOST_DEVICE, DEVICE_ARR
 
 
 def down_pass_uniform_2D_ItI(
-    boundary_imp_data: jax.Array,
+    boundary_data: jax.Array,
     S_lst: List[jax.Array],
     g_tilde_lst: List[jax.Array],
     Y_arr: jax.Array,
@@ -62,12 +62,12 @@ def down_pass_uniform_2D_ItI(
     """
     logging.debug(
         "down_pass_uniform_2D_ItI: started. boundary_imp_data shape: %s, len(g_tilde_lst): %s, len(S_lst): %s",
-        boundary_imp_data.shape,
+        boundary_data.shape,
         len(g_tilde_lst),
         len(S_lst),
     )
 
-    bdry_data = jax.device_put(boundary_imp_data, device)
+    bdry_data = jax.device_put(boundary_data, device)
     Y_arr = jax.device_put(Y_arr, device)
     v_arr = jax.device_put(v_arr, device)
     S_lst = [jax.device_put(S_arr, device) for S_arr in S_lst]

--- a/src/hahps/local_solve/__init__.py
+++ b/src/hahps/local_solve/__init__.py
@@ -3,6 +3,8 @@ from ._adaptive_2D_DtN import local_solve_stage_adaptive_2D_DtN
 from ._uniform_2D_ItI import local_solve_stage_uniform_2D_ItI
 from ._uniform_3D_DtN import local_solve_stage_uniform_3D_DtN
 from ._adaptive_3D_DtN import local_solve_stage_adaptive_3D_DtN
+from ._nosource_uniform_2D_DtN import nosource_local_solve_stage_uniform_2D_DtN
+from ._nosource_uniform_2D_ItI import nosource_local_solve_stage_uniform_2D_ItI
 
 __all__ = [
     "local_solve_stage_uniform_2D_DtN",
@@ -10,4 +12,6 @@ __all__ = [
     "local_solve_stage_uniform_2D_ItI",
     "local_solve_stage_uniform_3D_DtN",
     "local_solve_stage_adaptive_3D_DtN",
+    "nosource_local_solve_stage_uniform_2D_DtN",
+    "nosource_local_solve_stage_uniform_2D_ItI",
 ]

--- a/src/hahps/local_solve/_nosource_uniform_2D_DtN.py
+++ b/src/hahps/local_solve/_nosource_uniform_2D_DtN.py
@@ -1,0 +1,120 @@
+import jax.numpy as jnp
+import jax
+
+from .._pdeproblem import PDEProblem
+from .._device_config import DEVICE_ARR, HOST_DEVICE
+from ._uniform_2D_DtN import _gather_coeffs_2D, vmapped_assemble_diff_operator
+from typing import Tuple
+
+
+def nosource_local_solve_stage_uniform_2D_DtN(
+    pde_problem: PDEProblem,
+    device: jax.Device = DEVICE_ARR[0],
+    host_device: jax.Device = HOST_DEVICE,
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    """
+    This function performs the local solve stage for 2D problems with a uniform quadtree, creating DtN matrices.
+
+    Parameters
+    ----------
+    pde_problem : PDEProblem
+        Specifies the discretization, differential operator, source function, and keeps track of the pre-computed differentiation and interpolation matrices.
+    device : jax.Device
+        Where to perform the computation. Defaults to ``jax.devices()[0]``.
+    host_device : jax.Device
+        Where to place the output. Defaults to ``jax.devices("cpu")[0]``.
+
+    Returns
+    -------
+    Y : jax.Array
+        Solution operators mapping from Impedance boundary data to homogeneous solutions on the leaf interiors. Has shape (n_leaves, p^2, 4q)
+    T : jax.Array
+        Impedance-to-Impedance matrices for each leaf. Has shape (n_leaves, 4q, 4q)
+    """
+
+    # Gather the coefficients into a single array.
+    coeffs_gathered, which_coeffs = _gather_coeffs_2D(
+        D_xx_coeffs=pde_problem.D_xx_coefficients,
+        D_xy_coeffs=pde_problem.D_xy_coefficients,
+        D_yy_coeffs=pde_problem.D_yy_coefficients,
+        D_x_coeffs=pde_problem.D_x_coefficients,
+        D_y_coeffs=pde_problem.D_y_coefficients,
+        I_coeffs=pde_problem.I_coefficients,
+    )
+    # stack the precomputed differential operators into a single array
+    diff_ops = jnp.stack(
+        [
+            pde_problem.D_xx,
+            pde_problem.D_xy,
+            pde_problem.D_yy,
+            pde_problem.D_x,
+            pde_problem.D_y,
+            jnp.eye(pde_problem.D_xx.shape[0], dtype=jnp.float64),
+        ]
+    )
+
+    coeffs_gathered = jax.device_put(
+        coeffs_gathered,
+        device,
+    )
+
+    all_diff_operators = vmapped_assemble_diff_operator(
+        coeffs_gathered, which_coeffs, diff_ops
+    )
+
+    Y_arr, T_arr = vmapped_get_DtN_nosource(
+        all_diff_operators, pde_problem.Q, pde_problem.P
+    )
+
+    T_arr_host = jax.device_put(T_arr, host_device)
+    Y_arr_host = jax.device_put(Y_arr, host_device)
+
+    return Y_arr_host, T_arr_host
+
+
+@jax.jit
+def get_DtN_nosource(
+    diff_operator: jax.Array,
+    Q: jax.Array,
+    P: jax.Array,
+) -> Tuple[jax.Array, jax.Array]:
+    """
+    Computes the Dirichlet-to-Neumann operator for a given differential operator and boundary data.
+
+    Parameters
+    ----------
+    diff_operator : jax.Array
+        The differential operator to be applied.
+    Q : jax.Array
+        The boundary data.
+    P : jax.Array
+        The interpolation matrix.
+
+    Returns
+    -------
+    T : jax.Array
+        The Dirichlet-to-Neumann matrix.
+    Y : jax.Array
+        The solution operator mapping from Dirichlet boundary data to homogeneous solutions on the leaf interiors.
+    """
+    n_cheby_bdry = P.shape[0]
+
+    A_ii = diff_operator[n_cheby_bdry:, n_cheby_bdry:]
+    A_ii_inv = jnp.linalg.inv(A_ii)
+    # A_ie shape (n_cheby_int, n_cheby_bdry)
+    A_ie = diff_operator[n_cheby_bdry:, :n_cheby_bdry]
+    L_2 = jnp.zeros((diff_operator.shape[0], n_cheby_bdry), dtype=jnp.float64)
+    L_2 = L_2.at[:n_cheby_bdry].set(jnp.eye(n_cheby_bdry))
+    soln_operator = -1 * A_ii_inv @ A_ie
+    L_2 = L_2.at[n_cheby_bdry:].set(soln_operator)
+    Y = L_2 @ P
+    T = Q @ Y
+
+    return Y, T
+
+
+vmapped_get_DtN_nosource = jax.vmap(
+    get_DtN_nosource,
+    in_axes=(0, None, None),
+    out_axes=(0, 0),
+)

--- a/src/hahps/local_solve/_uniform_2D_DtN.py
+++ b/src/hahps/local_solve/_uniform_2D_DtN.py
@@ -192,7 +192,9 @@ def assemble_diff_operator(
 
     n_loops = which_coeffs.shape[0]
 
-    out = jnp.zeros_like(diff_ops[0])
+    # Initialize with the shape of diff_ops but the data type of coeffs_arr.
+    # This is important because we may want to use complex coefficients.
+    out = jnp.zeros_like(diff_ops[0], dtype=coeffs_arr.dtype)
 
     # Commenting this out because it is very memory intensive
     counter = 0

--- a/src/hahps/merge/__init__.py
+++ b/src/hahps/merge/__init__.py
@@ -3,6 +3,8 @@ from ._adaptive_2D_DtN import merge_stage_adaptive_2D_DtN
 from ._uniform_2D_ItI import merge_stage_uniform_2D_ItI
 from ._uniform_3D_DtN import merge_stage_uniform_3D_DtN
 from ._adaptive_3D_DtN import merge_stage_adaptive_3D_DtN
+from ._nosource_uniform_2D_DtN import nosource_merge_stage_uniform_2D_DtN
+from ._nosource_uniform_2D_ItI import nosource_merge_stage_uniform_2D_ItI
 
 __all__ = [
     "merge_stage_uniform_2D_DtN",
@@ -10,4 +12,6 @@ __all__ = [
     "merge_stage_uniform_2D_ItI",
     "merge_stage_uniform_3D_DtN",
     "merge_stage_adaptive_3D_DtN",
+    "nosource_merge_stage_uniform_2D_DtN",
+    "nosource_merge_stage_uniform_2D_ItI",
 ]

--- a/src/hahps/merge/_nosource_uniform_2D_DtN.py
+++ b/src/hahps/merge/_nosource_uniform_2D_DtN.py
@@ -1,0 +1,272 @@
+from typing import Tuple, List
+
+import jax
+import jax.numpy as jnp
+
+
+from ._schur_complement import (
+    nosource_assemble_merge_outputs_DtN,
+)
+from .._device_config import DEVICE_ARR, HOST_DEVICE
+from ._uniform_2D_DtN import (
+    get_quadmerge_blocks_a,
+    get_quadmerge_blocks_b,
+    get_quadmerge_blocks_c,
+    get_quadmerge_blocks_d,
+)
+import logging
+
+
+def nosource_merge_stage_uniform_2D_DtN(
+    T_arr: jax.Array,
+    l: int,
+    device: jax.Device = DEVICE_ARR[0],
+    host_device: jax.Device = HOST_DEVICE,
+    return_T: bool = False,
+) -> Tuple[List[jnp.ndarray], List[jnp.ndarray], List[jnp.ndarray]]:
+    """
+    Implements uniform 2D merges of DtN matrices. Merges the nodes in the quadtree four at a time.
+    This function uses a Schur complement strategy to reduce the size of matrix inverted in each merge operation.
+    This function returns lists containing :math:`S` and :math:`\\tilde{g}`, giving enough information
+    to propagate boundary data back down the tree in a later part of the algorithm.
+
+    If this function is called with the argument ``return_T=True``, the top-level DtN matrix is also returned.
+
+    Parameters
+    ----------
+
+    T_arr : jax.Array
+        Array of DtN matrices from the local solve stage. Has shape (n_leaves, 4q, 4q)
+
+    l : int
+        Number of levels to merge
+
+    device : jax.Device
+        Where to perform the computation. Defaults to jax.devices()[0].
+
+    host_device : jax.Device
+        Where to place the output. Defaults to jax.devices("cpu")[0].
+
+    return_T : bool
+        A flag to return the top-level T matrix. Defaults to False.
+
+    Returns
+    -------
+    S_lst : List[jax.Array]
+        A list of propagation operators. The first element of the list are the propagation operators for the nodes just above the leaves, and the last element of the list is the propagation operator for the root of the quadtree.
+
+    D_inv_lst : List[jax.Array]
+        List of pre-computed D^{-1} matrices for each level of the quadtree.
+
+    BD_inverse_lst : List[jax.Array]
+        List of pre-computed BD^{-1} matrices for each level of the quadtree.
+
+    T_last : jax.Array
+        The top-level DtN matrix, which is only returned if ``return_T=True``. Has shape (4q, 4q).
+
+    """
+
+    # Start lists to output data
+    S_lst = []
+    D_inv_lst = []
+    BD_inverse_lst = []
+
+    T_arr = jax.device_put(T_arr, device)
+
+    if len(T_arr.shape) < 4:
+        logging.debug(
+            "merge_stage_uniform_2D_DtN: T_arr.shape = %s", T_arr.shape
+        )
+        n_leaves, n_ext, _ = T_arr.shape
+        T_arr = T_arr.reshape(n_leaves // 4, 4, n_ext, n_ext)
+
+    for i in range(l - 1):
+        S_arr, T_arr_new, D_inv_arr, BD_inv_arr = (
+            vmapped_nosource_uniform_quad_merge_DtN(T_arr)
+        )
+
+        # TODO: Figure out how to safely delete these arrays
+        # when using autodiff.
+
+        # T_arr.delete()
+        # h_arr.delete()
+
+        if host_device != device:
+            S_host = jax.device_put(S_arr, host_device)
+            S_lst.append(S_host)
+            S_arr.delete()
+
+            D_inv_host = jax.device_put(D_inv_arr, host_device)
+            D_inv_lst.append(D_inv_host)
+            D_inv_arr.delete()
+
+            BD_inv_host = jax.device_put(BD_inv_arr, host_device)
+            BD_inverse_lst.append(BD_inv_host)
+            BD_inv_arr.delete()
+        else:
+            S_lst.append(S_arr)
+            D_inv_lst.append(D_inv_arr)
+            BD_inverse_lst.append(BD_inv_arr)
+
+        T_arr = T_arr_new
+
+    S_last, T_last, D_inv_last, BD_inv_last = _nosource_uniform_quad_merge_DtN(
+        T_arr[0, 0],
+        T_arr[0, 1],
+        T_arr[0, 2],
+        T_arr[0, 3],
+    )
+
+    S_lst.append(jax.device_put(jnp.expand_dims(S_last, axis=0), host_device))
+    D_inv_lst.append(
+        jax.device_put(jnp.expand_dims(D_inv_last, axis=0), host_device)
+    )
+    BD_inverse_lst.append(
+        jax.device_put(jnp.expand_dims(BD_inv_last, axis=0), host_device)
+    )
+
+    if return_T:
+        T_last_out = jax.device_put(T_last, host_device)
+        return (S_lst, D_inv_lst, BD_inverse_lst, T_last_out)
+    else:
+        return (S_lst, D_inv_lst, BD_inverse_lst)
+
+
+@jax.jit
+def _nosource_uniform_quad_merge_DtN(
+    T_a: jax.Array,
+    T_b: jax.Array,
+    T_c: jax.Array,
+    T_d: jax.Array,
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    n_a = T_a.shape[0]
+    dummy_h = jnp.zeros((n_a,), dtype=T_a.dtype)
+    # First, find all of the necessary submatrices and sub-vectors
+    (
+        _,
+        _,
+        _,
+        T_a_11,
+        T_a_15,
+        T_a_18,
+        T_a_51,
+        T_a_55,
+        T_a_58,
+        T_a_81,
+        T_a_85,
+        T_a_88,
+    ) = get_quadmerge_blocks_a(T_a, dummy_h)
+
+    (
+        _,
+        _,
+        _,
+        T_b_22,
+        T_b_26,
+        T_b_25,
+        T_b_62,
+        T_b_66,
+        T_b_65,
+        T_b_52,
+        T_b_56,
+        T_b_55,
+    ) = get_quadmerge_blocks_b(T_b, dummy_h)
+
+    (
+        _,
+        _,
+        _,
+        T_c_66,
+        T_c_63,
+        T_c_67,
+        T_c_36,
+        T_c_33,
+        T_c_37,
+        T_c_76,
+        T_c_73,
+        T_c_77,
+    ) = get_quadmerge_blocks_c(T_c, dummy_h)
+
+    (
+        _,
+        _,
+        _,
+        T_d_88,
+        T_d_87,
+        T_d_84,
+        T_d_78,
+        T_d_77,
+        T_d_74,
+        T_d_48,
+        T_d_47,
+        T_d_44,
+    ) = get_quadmerge_blocks_d(T_d, dummy_h)
+
+    n_int, n_ext = T_a_51.shape
+
+    zero_block_ei = jnp.zeros((n_ext, n_int))
+    zero_block_ie = jnp.zeros((n_int, n_ext))
+    zero_block_ii = jnp.zeros((n_int, n_int))
+
+    # A t_ext + B t_int = g_ext - h_ext
+    B = jnp.block(
+        [
+            [T_a_15, zero_block_ei, zero_block_ei, T_a_18],
+            [T_b_25, T_b_26, zero_block_ei, zero_block_ei],
+            [zero_block_ei, T_c_36, T_c_37, zero_block_ei],
+            [zero_block_ei, zero_block_ei, T_d_47, T_d_48],
+        ]
+    )
+    C = jnp.block(
+        [
+            [T_a_51, T_b_52, zero_block_ie, zero_block_ie],
+            [zero_block_ie, T_b_62, T_c_63, zero_block_ie],
+            [zero_block_ie, zero_block_ie, T_c_73, T_d_74],
+            [T_a_81, zero_block_ie, zero_block_ie, T_d_84],
+        ]
+    )
+
+    D = jnp.block(
+        [
+            [T_a_55 + T_b_55, T_b_56, zero_block_ii, T_a_58],
+            [T_b_65, T_b_66 + T_c_66, T_c_67, zero_block_ii],
+            [zero_block_ii, T_c_76, T_c_77 + T_d_77, T_d_78],
+            [T_a_85, zero_block_ii, T_d_87, T_d_88 + T_a_88],
+        ]
+    )
+    A_lst = [T_a_11, T_b_22, T_c_33, T_d_44]
+
+    T, S, D_inv, BD_inv = nosource_assemble_merge_outputs_DtN(A_lst, B, C, D)
+
+    # Roll the exterior by n_int to get the correct ordering
+    # of the exterior discretization points. Right now, the exterior points are ordered like [a_1, b_2, c_3, d_4]
+    # but we want [bottom, left, top, right]. This requires
+    # rolling the exterior points by n_int.
+    T = jnp.roll(T, -n_int, axis=0)
+    T = jnp.roll(T, -n_int, axis=1)
+    S = jnp.roll(S, -n_int, axis=1)
+
+    return S, T, D_inv, BD_inv
+
+
+_vmapped_nosource_uniform_quad_merge_DtN = jax.vmap(
+    _nosource_uniform_quad_merge_DtN,
+    in_axes=(0, 0, 0, 0),
+    out_axes=(0, 0, 0, 0),
+)
+
+
+@jax.jit
+def vmapped_nosource_uniform_quad_merge_DtN(
+    R_in: jax.Array,
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    S, R, D_inv, BD_inv = _vmapped_nosource_uniform_quad_merge_DtN(
+        R_in[:, 0],
+        R_in[:, 1],
+        R_in[:, 2],
+        R_in[:, 3],
+    )
+
+    n_merges, n_int, n_ext = S.shape
+    R = R.reshape((n_merges // 4, 4, n_ext, n_ext))
+    return S, R, D_inv, BD_inv

--- a/src/hahps/merge/_schur_complement.py
+++ b/src/hahps/merge/_schur_complement.py
@@ -5,14 +5,14 @@ import jax.numpy as jnp
 
 @jax.jit
 def assemble_merge_outputs_ItI(
-    A_lst: List[jnp.array],
-    B: jnp.array,
-    C: jnp.array,
-    D_12: jnp.array,
+    A_lst: List[jax.Array],
+    B: jax.Array,
+    C: jax.Array,
+    D_12: jax.Array,
     D_21: jax.Array,
-    h_ext: jnp.array,
-    h_int: jnp.array,
-) -> Tuple[jnp.array, jnp.array, jnp.array, jnp.array]:
+    h_ext: jax.Array,
+    h_int: jax.Array,
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     """
     Performs a merge for ItI matrices. In the ItI case, the D matrix is structured like:
             ------------
@@ -21,20 +21,20 @@ def assemble_merge_outputs_ItI(
             -------------
     So we invert it with a Schur complement method and then pass the data to _assemble_merge_outputs()
     Args:
-        A_lst (List[jnp.array]): _description_
-        B (jnp.array): _description_
-        C (jnp.array): _description_
-        D (jnp.array): _description_
-        h_ext (jnp.array): _description_
-        h_int (jnp.array): _description_
+        A_lst (List[jax.Array]): _description_
+        B (jax.Array): _description_
+        C (jax.Array): _description_
+        D (jax.Array): _description_
+        h_ext (jax.Array): _description_
+        h_int (jax.Array): _description_
 
     Returns:
-        Tuple[jnp.array, jnp.array, jnp.array, jnp.array]
+        Tuple[jax.Array, jax.Array, jax.Array, jax.Array]
 
-        T (jnp.array): DtN matrix
-        S (jnp.array): ext_to_int matrix
-        h_ext_out (jnp.array): particular soln outgoing data on the boundary of the merged patches.
-        g_tilde_int (jnp.array): particular soln incoming data on the merge interfaces.
+        T (jax.Array): DtN matrix
+        S (jax.Array): ext_to_int matrix
+        h_ext_out (jax.Array): particular soln outgoing data on the boundary of the merged patches.
+        g_tilde_int (jax.Array): particular soln incoming data on the merge interfaces.
     """
 
     D_inv = _invert_D_ItI(D_12, D_21)
@@ -43,12 +43,12 @@ def assemble_merge_outputs_ItI(
 
 @jax.jit
 def nosource_assemble_merge_outputs_ItI(
-    A_lst: List[jnp.array],
-    B: jnp.array,
-    C: jnp.array,
-    D_12: jnp.array,
+    A_lst: List[jax.Array],
+    B: jax.Array,
+    C: jax.Array,
+    D_12: jax.Array,
     D_21: jax.Array,
-) -> Tuple[jnp.array, jnp.array, jnp.array, jnp.array]:
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     """
     Performs a merge for ItI matrices. In the ItI case, the D matrix is structured like:
             ------------
@@ -57,18 +57,18 @@ def nosource_assemble_merge_outputs_ItI(
             -------------
     So we invert it with a Schur complement method and then pass the data to _assemble_merge_outputs()
     Args:
-        A_lst (List[jnp.array]): _description_
-        B (jnp.array): _description_
-        C (jnp.array): _description_
-        D (jnp.array): _description_
+        A_lst (List[jax.Array]): _description_
+        B (jax.Array): _description_
+        C (jax.Array): _description_
+        D (jax.Array): _description_
 
     Returns:
-        Tuple[jnp.array, jnp.array, jnp.array, jnp.array]
+        Tuple[jax.Array, jax.Array, jax.Array, jax.Array]
 
-        T (jnp.array): DtN matrix
-        S (jnp.array): ext_to_int matrix
-        D^{-1} (jnp.array):
-        BD^{-1} (jnp.array):
+        T (jax.Array): DtN matrix
+        S (jax.Array): ext_to_int matrix
+        D^{-1} (jax.Array):
+        BD^{-1} (jax.Array):
     """
 
     D_inv = _invert_D_ItI(D_12, D_21)
@@ -113,31 +113,31 @@ def _invert_D_ItI(D_12: jax.Array, D_21: jax.Array) -> jax.Array:
 
 @jax.jit
 def assemble_merge_outputs_DtN(
-    A_lst: List[jnp.array],
-    B: jnp.array,
-    C: jnp.array,
-    D: jnp.array,
-    h_ext: jnp.array,
-    h_int: jnp.array,
-) -> Tuple[jnp.array, jnp.array, jnp.array, jnp.array]:
+    A_lst: List[jax.Array],
+    B: jax.Array,
+    C: jax.Array,
+    D: jax.Array,
+    h_ext: jax.Array,
+    h_int: jax.Array,
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     """
     Inverts D, which is dense in the DtN case, and then passes the data to _assemble_merge_outputs()
 
     Args:
-        A_lst (List[jnp.array]): _description_
-        B (jnp.array): _description_
-        C (jnp.array): _description_
-        D (jnp.array): _description_
-        h_ext (jnp.array): _description_
-        h_int (jnp.array): _description_
+        A_lst (List[jax.Array]): _description_
+        B (jax.Array): _description_
+        C (jax.Array): _description_
+        D (jax.Array): _description_
+        h_ext (jax.Array): _description_
+        h_int (jax.Array): _description_
 
     Returns:
-        Tuple[jnp.array, jnp.array, jnp.array, jnp.array]
+        Tuple[jax.Array, jax.Array, jax.Array, jax.Array]
 
-        T (jnp.array): DtN matrix
-        S (jnp.array): ext_to_int matrix
-        h_ext_out (jnp.array): particular soln outgoing data on the boundary of the merged patches.
-        g_tilde_int (jnp.array): particular soln incoming data on the merge interfaces.
+        T (jax.Array): DtN matrix
+        S (jax.Array): ext_to_int matrix
+        h_ext_out (jax.Array): particular soln outgoing data on the boundary of the merged patches.
+        g_tilde_int (jax.Array): particular soln incoming data on the merge interfaces.
     """
 
     D_inv = jnp.linalg.inv(D)
@@ -145,14 +145,46 @@ def assemble_merge_outputs_DtN(
 
 
 @jax.jit
+def nosource_assemble_merge_outputs_DtN(
+    A_lst: List[jax.Array],
+    B: jax.Array,
+    C: jax.Array,
+    D: jax.Array,
+) -> Tuple[
+    jax.Array,
+    jax.Array,
+]:
+    """
+    Inverts D, which is dense in the DtN case, and then passes the data to _assemble_merge_outputs()
+
+    Args:
+        A_lst (List[jax.Array]): _description_
+        B (jax.Array): _description_
+        C (jax.Array): _description_
+        D (jax.Array): _description_
+        h_ext (jax.Array): _description_
+        h_int (jax.Array): _description_
+
+    Returns:
+        Tuple[jax.Array, jax.Array, jax.Array, jax.Array]
+
+        T (jax.Array): DtN matrix
+        S (jax.Array): ext_to_int matrix
+    """
+
+    D_inv = jnp.linalg.inv(D)
+    return _nosource_assemble_merge_outputs(A_lst, B, C, D_inv)
+
+
+@jax.jit
 def _assemble_merge_outputs(
-    A_lst: List[jnp.array],
-    B: jnp.array,
-    C: jnp.array,
-    D_inv: jnp.array,
-    h_ext: jnp.array,
-    h_int: jnp.array,
-) -> Tuple[jnp.array, jnp.array, jnp.array, jnp.array]:
+    A_lst: List[jax.Array],
+    B: jax.Array,
+    C: jax.Array,
+    D_inv: jax.Array,
+    h_ext: jax.Array,
+    h_int: jax.Array,
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     """
     Computes a Schur complement that shows up in merging
     four patches together. Assumes D is already inverted.
@@ -168,20 +200,20 @@ def _assemble_merge_outputs(
     [D^{-1}C       I][g_int]   [-D^{-1} h_int]
 
     Args:
-        A_lst (List[jnp.array]): List of square diagonal blocks which make up A
-        B (jnp.array):
-        C (jnp.array): _description_
-        D_inv (jnp.array): _description_
-        h_ext (jnp.array): _description_
-        h_int (jnp.array): _description_
+        A_lst (List[jax.Array]): List of square diagonal blocks which make up A
+        B (jax.Array):
+        C (jax.Array): _description_
+        D_inv (jax.Array): _description_
+        h_ext (jax.Array): _description_
+        h_int (jax.Array): _description_
 
     Returns:
-        Tuple[jnp.array, jnp.array, jnp.array, jnp.array]
+        Tuple[jax.Array, jax.Array, jax.Array, jax.Array]
 
-        T (jnp.array): DtN matrix
-        S (jnp.array): Propagation matrix
-        h_ext_out (jnp.array): particular soln outgoing data on the boundary of the merged patches.
-        g_tilde_int (jnp.array): particular soln incoming data on the merge interfaces.
+        T (jax.Array): DtN matrix
+        S (jax.Array): Propagation matrix
+        h_ext_out (jax.Array): particular soln outgoing data on the boundary of the merged patches.
+        g_tilde_int (jax.Array): particular soln incoming data on the merge interfaces.
     """
 
     S = -1 * D_inv @ C
@@ -204,11 +236,11 @@ def _assemble_merge_outputs(
 
 @jax.jit
 def _nosource_assemble_merge_outputs(
-    A_lst: List[jnp.array],
-    B: jnp.array,
-    C: jnp.array,
-    D_inv: jnp.array,
-) -> Tuple[jnp.array, jnp.array, jnp.array, jnp.array]:
+    A_lst: List[jax.Array],
+    B: jax.Array,
+    C: jax.Array,
+    D_inv: jax.Array,
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     """
     Computes a Schur complement that shows up in merging
     four patches together. Assumes D is already inverted.
@@ -226,18 +258,18 @@ def _nosource_assemble_merge_outputs(
     This returns the matrices T, S, D^{-1}, BD^{-1}
 
     Args:
-        A_lst (List[jnp.array]): List of square diagonal blocks which make up A
-        B (jnp.array):
-        C (jnp.array): _description_
-        D_inv (jnp.array): _description_
+        A_lst (List[jax.Array]): List of square diagonal blocks which make up A
+        B (jax.Array):
+        C (jax.Array): _description_
+        D_inv (jax.Array): _description_
 
     Returns:
-        Tuple[jnp.array, jnp.array, jnp.array, jnp.array]
+        Tuple[jax.Array, jax.Array, jax.Array, jax.Array]
 
-        T (jnp.array): DtN matrix
-        S (jnp.array): Propagation matrix
-        D^{-1} (jnp.array):
-        BD^{-1} (jnp.array):
+        T (jax.Array): DtN matrix
+        S (jax.Array): Propagation matrix
+        D^{-1} (jax.Array):
+        BD^{-1} (jax.Array):
     """
 
     S = -1 * D_inv @ C
@@ -257,15 +289,15 @@ def _nosource_assemble_merge_outputs(
 
 @jax.jit
 def _oct_merge_from_submatrices(
-    a_submatrices_subvecs: Tuple[jnp.array],
-    b_submatrices_subvecs: Tuple[jnp.array],
-    c_submatrices_subvecs: Tuple[jnp.array],
-    d_submatrices_subvecs: Tuple[jnp.array],
-    e_submatrices_subvecs: Tuple[jnp.array],
-    f_submatrices_subvecs: Tuple[jnp.array],
-    g_submatrices_subvecs: Tuple[jnp.array],
-    h_submatrices_subvecs: Tuple[jnp.array],
-) -> Tuple[jnp.array, jnp.array, jnp.array, jnp.array]:
+    a_submatrices_subvecs: Tuple[jax.Array],
+    b_submatrices_subvecs: Tuple[jax.Array],
+    c_submatrices_subvecs: Tuple[jax.Array],
+    d_submatrices_subvecs: Tuple[jax.Array],
+    e_submatrices_subvecs: Tuple[jax.Array],
+    f_submatrices_subvecs: Tuple[jax.Array],
+    g_submatrices_subvecs: Tuple[jax.Array],
+    h_submatrices_subvecs: Tuple[jax.Array],
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     (
         T_a_1_1,
         T_a_1_9,

--- a/src/hahps/up_pass/__init__.py
+++ b/src/hahps/up_pass/__init__.py
@@ -1,5 +1,7 @@
 from ._uniform_2D_ItI import up_pass_uniform_2D_ItI
+from ._uniform_2D_DtN import up_pass_uniform_2D_DtN
 
 __all__ = [
     "up_pass_uniform_2D_ItI",
+    "up_pass_uniform_2D_DtN",
 ]

--- a/src/hahps/up_pass/_uniform_2D_DtN.py
+++ b/src/hahps/up_pass/_uniform_2D_DtN.py
@@ -1,0 +1,153 @@
+from typing import List, Tuple
+import jax
+import jax.numpy as jnp
+from .._device_config import HOST_DEVICE, DEVICE_ARR
+from .._pdeproblem import PDEProblem
+from ..local_solve._uniform_2D_DtN import local_solve_stage_uniform_2D_DtN
+import logging
+
+
+def up_pass_uniform_2D_DtN(
+    source: jax.Array,
+    pde_problem: PDEProblem,
+    device: jax.Device = DEVICE_ARR[0],
+    host_device: jax.Device = HOST_DEVICE,
+    return_h_last: bool = False,
+) -> Tuple[jax.Array, List[jax.Array], jax.Array]:
+    """
+    This function performs the upward pass for 2D DtN problems. It recomputes the local solve stage to get
+    outgoing impedance data from the particular solution, which is now known because the source is specified.
+
+
+
+    Parameters
+    ----------
+    source : jax.Array
+        Specifies the source term(s). Can have shape (nleaves, p^2) or (nleaves, p^2, nsrc).
+
+    pde_probem : PDEProblem
+        Specifies the discretization, differential operator, source function, and keeps track of the pre-computed differentiation and interpolation matrices.
+
+    device : jax.Device, optional
+        Where to perform the computation. Defaults to ``jax.devices()[0]``.
+
+    host_device : jax.Device, optional
+        Where to place the output. Defaults to ``jax.devices("cpu")[0]``.
+
+    return_h_last : bool, optional
+        If True, return the last h vector, which gives the outward pointing normal derivative data for the particular solution evaluated at the domain boundary.
+
+    Returns
+    -------
+    v : jax.Array
+        Leaf-level particular solutions. Has shape (n_leaves, p^2)
+
+    g_tilde_lst : List[jax.Array]
+        List of pre-computed g_tilde matrices for each level of the quadtree.
+
+    h_last : jax.Array
+        Outward pointing normal derivative data for the particular solution evaluated at the domain boundary. Has shape (nbdry, nsrc). Is only returned if ``return_h_last=True``.
+    """
+
+    # Re-do a full local solve.
+    pde_problem.source = source
+
+    # Get the saved D_inv_lst and BD_inv_lst
+    D_inv_lst = pde_problem.D_inv_lst
+    BD_inv_lst = pde_problem.BD_inv_lst
+
+    Y, T, v, h_in = local_solve_stage_uniform_2D_DtN(
+        pde_problem=pde_problem,
+        device=device,
+        host_device=host_device,
+    )
+    logging.debug(
+        "up_pass_uniform_2D_DtN: after local solve, h_in shape = %s",
+        h_in.shape,
+    )
+
+    g_tilde_lst = []
+
+    for i in range(len(D_inv_lst)):
+        # Get h and g_tilde for this level
+
+        nnodes, nbdry = h_in.shape
+        h_in = h_in.reshape(nnodes // 4, 4, nbdry)
+        D_inv = D_inv_lst[i]
+        BD_inv = BD_inv_lst[i]
+
+        h_in, g_tilde = vmapped_assemble_boundary_data_DtN(h_in, D_inv, BD_inv)
+        g_tilde_lst.append(g_tilde)
+
+    out = (v, g_tilde_lst)
+
+    if return_h_last:
+        out = (v, g_tilde_lst, jnp.squeeze(h_in, axis=0))
+
+    return out
+
+
+@jax.jit
+def assemble_boundary_data_DtN(
+    h_in: jax.Array,
+    D_inv: jax.Array,
+    BD_inv: jax.Array,
+) -> Tuple[jax.Array, jax.Array]:
+    """
+
+
+    Args:
+        h_in (jax.Array): Has shape (4, 4 * nside, n_src) where nside is the number of discretization points along each side of the nodes being merged.
+        D_inv (jax.Array): Has shape (8 * nside, 8 * nside)
+        BD_inv (jax.Array): Has shape (8 * nside, 8 * nside)
+
+    Returns:
+        h : jax.Array
+            Has shape (8 * nside, n_src) and is the outgoing impedance data due to the particular solution on the merged node.
+        g_tilde : jax.Array
+            Has shape (8 * nside, n_src) and is the incoming impedance data due to the particular solution on the merged node, evaluated along the merge interfaces.
+    """
+
+    nside = h_in.shape[1] // 4
+
+    # Remember, the slices along the merge interface go from OUTSIDE to INSIDE
+    h_a = h_in[0]
+    h_a_1 = jnp.concatenate([h_a[-nside:], h_a[:nside]])
+    h_a_5 = h_a[nside : 2 * nside]
+    h_a_8 = jnp.flipud(h_a[2 * nside : 3 * nside])
+
+    h_b = h_in[1]
+    h_b_2 = h_b[: 2 * nside]
+    h_b_6 = h_b[2 * nside : 3 * nside]
+    h_b_5 = jnp.flipud(h_b[3 * nside : 4 * nside])
+
+    h_c = h_in[2]
+    h_c_6 = jnp.flipud(h_c[:nside])
+    h_c_3 = h_c[nside : 3 * nside]
+    h_c_7 = h_c[3 * nside : 4 * nside]
+
+    h_d = h_in[3]
+    h_d_8 = h_d[:nside]
+    h_d_7 = jnp.flipud(h_d[nside : 2 * nside])
+    h_d_4 = h_d[2 * nside : 4 * nside]
+
+    h_int_child = jnp.concatenate(
+        [h_a_5 + h_b_5, h_b_6 + h_c_6, h_c_7 + h_d_7, h_d_8 + h_a_8]
+    )
+
+    h_ext_child = jnp.concatenate([h_a_1, h_b_2, h_c_3, h_d_4])
+
+    g_tilde = -1 * D_inv @ h_int_child
+
+    h = h_ext_child - BD_inv @ h_int_child
+
+    # h is ordered like h_a_1, h_b_2, h_c_3, h_d_4. Need to
+    # roll it so that it's ordered like [bottom, left, right, top].
+    h = jnp.roll(h, -nside, axis=0)
+
+    return h, g_tilde
+
+
+vmapped_assemble_boundary_data_DtN = jax.vmap(
+    assemble_boundary_data_DtN, in_axes=(0, 0, 0), out_axes=(0, 0)
+)

--- a/tests/test_accuracy/cases.py
+++ b/tests/test_accuracy/cases.py
@@ -133,7 +133,7 @@ TEST_CASE_POLY_ZERO_SOURCE = {
 
 
 # ######################################################################
-# # Test Case 2: Polynomial Source Function for ItI Problems
+# # Test Case 2: Non-polynomial Source Function for ItI Problems
 # # \Delta u + q(x) u(x) = f     in \Omega
 # # u_n + i u = 0                in \partial \Omega
 # #
@@ -206,4 +206,60 @@ TEST_CASE_HELMHOLTZ_ITI = {
     K_SOLN: u,
     K_DUDX: dudx,
     K_DUDY: dudy,
+}
+
+
+# ######################################################################
+# # Test Case 3: Polynomial Source Function for ItI Problems
+# # \Delta u + (k^2 + i \gamma) u(x) = f     in \Omega
+# # u_n + i u = g               in \partial \Omega
+# #
+# #
+# # u(x,y) = x^3 + 3 y^2
+# # f(x,y) = 6x + 6 + (k^2 + i \gamma) u(x,y)
+# # g(x,y) = defined piecewise
+# # Can't separate the solution into homogeneous and particular parts, but here
+# # is the solution:
+# # u(x,y) = e^{i  \pi x} + e^{i  \pi y}
+
+
+# This is (k^2 + i \gamma)
+# k = 1.0; gamma = 0.1
+COMPLEX_COEFF = 1j * 0.1 + 1.0
+
+
+def u_complex_coeffs(x: jax.Array) -> jax.Array:
+    # u(x,y) = x^3 + 3 y^2
+    return jnp.power(x[..., 0], 3) + 3 * jnp.square(x[..., 1])
+
+
+def i_complex_coeffs(x: jax.Array) -> jax.Array:
+    # q(x,y) = k^2 + i \gamma
+    return COMPLEX_COEFF * jnp.ones_like(x[..., 0])
+
+
+def source_complex_coeffs(x: jax.Array) -> jax.Array:
+    # f(x,y) = 6x + 6 + (k^2 + i \gamma) u(x,y)
+    return 6 * x[..., 0] + 6 + COMPLEX_COEFF * u_complex_coeffs(x)
+
+
+def dudx_complex_coeffs(x: jax.Array) -> jax.Array:
+    # du/dx = 3x^2
+    return 3 * jnp.square(x[..., 0])
+
+
+def dudy_complex_coeffs(x: jax.Array) -> jax.Array:
+    # du/dy = 6y
+    return 6 * x[..., 1]
+
+
+TEST_CASE_HELMHOLTZ_ITI_COMPLEX_COEFFS = {
+    K_DIRICHLET: u_complex_coeffs,
+    K_XX_COEFF: default_lap_coeffs,
+    K_YY_COEFF: default_lap_coeffs,
+    K_I_COEFF: i_complex_coeffs,
+    K_SOURCE: source_complex_coeffs,
+    K_SOLN: u_complex_coeffs,
+    K_DUDX: dudx_complex_coeffs,
+    K_DUDY: dudy_complex_coeffs,
 }

--- a/tests/test_accuracy/test_local_solve_stage_accuracy.py
+++ b/tests/test_accuracy/test_local_solve_stage_accuracy.py
@@ -22,6 +22,7 @@ from .cases import (
     TEST_CASE_POLY_PART_HOMOG,
     TEST_CASE_POLY_ZERO_SOURCE,
     TEST_CASE_HELMHOLTZ_ITI,
+    TEST_CASE_HELMHOLTZ_ITI_COMPLEX_COEFFS,
     K_DIRICHLET,
     K_XX_COEFF,
     K_YY_COEFF,
@@ -519,6 +520,14 @@ class Test_accuracy_local_solve_stage_uniform_2D_ItI:
         """
         caplog.set_level(logging.DEBUG)
         test_case = TEST_CASE_HELMHOLTZ_ITI
+        domain = DOMAIN_ITI
+        check_leaf_accuracy_ItI_Helmholtz_like(domain, test_case)
+        jax.clear_caches()
+
+    def test_2(self, caplog) -> None:
+        """Uses TEST_CASE_HELMHOLTZ_ITI_COMPLEX_COEFFS. Tests the accuracy when the coefficients are complex-valued."""
+        caplog.set_level(logging.DEBUG)
+        test_case = TEST_CASE_HELMHOLTZ_ITI_COMPLEX_COEFFS
         domain = DOMAIN_ITI
         check_leaf_accuracy_ItI_Helmholtz_like(domain, test_case)
         jax.clear_caches()

--- a/tests/test_accuracy/test_single_merge_accuracy.py
+++ b/tests/test_accuracy/test_single_merge_accuracy.py
@@ -23,6 +23,7 @@ from .cases import (
     TEST_CASE_POLY_PART_HOMOG,
     TEST_CASE_POLY_ZERO_SOURCE,
     TEST_CASE_HELMHOLTZ_ITI,
+    TEST_CASE_HELMHOLTZ_ITI_COMPLEX_COEFFS,
     K_DIRICHLET,
     K_XX_COEFF,
     K_YY_COEFF,
@@ -396,6 +397,15 @@ class Test_accuracy_single_merge_2D_ItI_uniform:
 
         check_merge_accuracy_2D_ItI_uniform_Helmholtz_like(
             DOMAIN_ITI_NONPOLY, TEST_CASE_HELMHOLTZ_ITI
+        )
+        jax.clear_caches()
+
+    def test_2(self, caplog) -> None:
+        """Complex coefficients."""
+        caplog.set_level(logging.DEBUG)
+
+        check_merge_accuracy_2D_ItI_uniform_Helmholtz_like(
+            DOMAIN_ITI_NONPOLY, TEST_CASE_HELMHOLTZ_ITI_COMPLEX_COEFFS
         )
         jax.clear_caches()
 

--- a/tests/test_build_solver.py
+++ b/tests/test_build_solver.py
@@ -360,8 +360,44 @@ class Test_build_solver:
         assert T.shape == (n_bdry, n_bdry)
 
         assert len(pde_problem.S_lst) == L
-        assert len(pde_problem.g_tilde_lst) == L
 
         # g_tilde has shape n_bdry in the ItI case.
         assert pde_problem.S_lst[-1].shape == (1, n_bdry, n_bdry)
-        assert pde_problem.g_tilde_lst[-1].shape == (1, n_bdry)
+
+    def test_8(self, caplog) -> None:
+        """Uniform 2D DtN with no source"""
+        caplog.set_level(logging.DEBUG)
+        p = 6
+        q = 4
+        L = 2
+
+        # Create a uniform 2D domain
+        root = DiscretizationNode2D(xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0)
+
+        domain = Domain(p=p, q=q, root=root, L=L)
+
+        d_xx_coeffs = jnp.array(
+            np.random.normal(size=domain.interior_points[..., 0].shape)
+        )
+
+        d_yy_coeffs = jnp.array(
+            np.random.normal(size=domain.interior_points[..., 0].shape)
+        )
+
+        # Create a PDEProblem instance
+        pde_problem = PDEProblem(
+            domain=domain,
+            D_xx_coefficients=d_xx_coeffs,
+            D_yy_coefficients=d_yy_coeffs,
+        )
+
+        # Build the solver
+        T = build_solver(pde_problem, return_top_T=True)
+
+        n_bdry = domain.boundary_points.shape[0]
+        assert T.shape == (n_bdry, n_bdry)
+
+        assert len(pde_problem.S_lst) == L
+
+        # g_tilde has shape n_bdry in the ItI case.
+        assert pde_problem.S_lst[-1].shape == (1, n_bdry // 2, n_bdry)

--- a/tests/test_down_pass/test_uniform_2D_ItI.py
+++ b/tests/test_down_pass/test_uniform_2D_ItI.py
@@ -108,7 +108,7 @@ class Test_down_pass_uniform_2D_ItI:
 
         bdry_data = jnp.ones((n_bdry))
         out = down_pass_uniform_2D_ItI(
-            boundary_imp_data=bdry_data,
+            boundary_data=bdry_data,
             S_lst=S_lst,
             g_tilde_lst=g_tilde_lst,
             Y_arr=None,

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -327,3 +327,59 @@ class Test_solve:
 
         solns2 = solve(pde_problem, bdry_data2, source=source2)
         assert solns2.shape == (domain.interior_points[..., 0].shape)
+
+    def test_6(self, caplog) -> None:
+        """Uniform 2D DtN with up and down passes"""
+        caplog.set_level(logging.DEBUG)
+        p = 6
+        q = 4
+        L = 2
+
+        # Create a uniform 2D domain
+        root = DiscretizationNode2D(xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0)
+
+        domain = Domain(p=p, q=q, root=root, L=L)
+
+        d_xx_coeffs = jnp.array(
+            np.random.normal(size=domain.interior_points[..., 0].shape)
+        )
+
+        d_yy_coeffs = jnp.array(
+            np.random.normal(size=domain.interior_points[..., 0].shape)
+        )
+
+        # Create a PDEProblem instance
+        pde_problem = PDEProblem(
+            domain=domain,
+            D_xx_coefficients=d_xx_coeffs,
+            D_yy_coefficients=d_yy_coeffs,
+        )
+
+        # Build the solver
+        T = build_solver(pde_problem, return_top_T=True)
+
+        n_bdry = domain.boundary_points.shape[0]
+        assert T.shape == (n_bdry, n_bdry)
+
+        assert len(pde_problem.S_lst) == L
+
+        # g_tilde has shape n_bdry in the ItI case.
+        assert pde_problem.S_lst[-1].shape == (1, n_bdry // 2, n_bdry)
+        # Solve the problem
+        bdry_data = jnp.array(np.random.normal(size=n_bdry))
+
+        source = jnp.array(
+            np.random.normal(size=domain.interior_points[..., 0].shape)
+        )
+
+        solns = solve(pde_problem, bdry_data, source=source)
+
+        assert solns.shape == (domain.interior_points[..., 0].shape)
+
+        source2 = jnp.array(
+            np.random.normal(size=domain.interior_points[..., 0].shape)
+        )
+        bdry_data2 = jnp.array(np.random.normal(size=n_bdry))
+
+        solns2 = solve(pde_problem, bdry_data2, source=source2)
+        assert solns2.shape == (domain.interior_points[..., 0].shape)


### PR DESCRIPTION
This PR includes improvements that allow 2D uniform problems to call the `build_solver()` routine before the source is specified. This means the source can be specified at the time of calling `solve()`, which will allow for faster computations in settings where one needs to compute a PDE for a large number of right-hand-sides. 