### PR TITLE
fix: use dynamic dtype instead of float64 in DtN maps

### DIFF
--- a/src/jaxhps/local_solve/_nosource_uniform_2D_DtN.py
+++ b/src/jaxhps/local_solve/_nosource_uniform_2D_DtN.py
@@ -104,7 +104,9 @@ def get_DtN_nosource(
     A_ii_inv = jnp.linalg.inv(A_ii)
     # A_ie shape (n_cheby_int, n_cheby_bdry)
     A_ie = diff_operator[n_cheby_bdry:, :n_cheby_bdry]
-    L_2 = jnp.zeros((diff_operator.shape[0], n_cheby_bdry), dtype=diff_operator.dtype)
+    L_2 = jnp.zeros(
+        (diff_operator.shape[0], n_cheby_bdry), dtype=diff_operator.dtype
+    )
     L_2 = L_2.at[:n_cheby_bdry].set(jnp.eye(n_cheby_bdry))
     soln_operator = -1 * A_ii_inv @ A_ie
     L_2 = L_2.at[n_cheby_bdry:].set(soln_operator)

--- a/src/jaxhps/local_solve/_nosource_uniform_2D_DtN.py
+++ b/src/jaxhps/local_solve/_nosource_uniform_2D_DtN.py
@@ -104,7 +104,7 @@ def get_DtN_nosource(
     A_ii_inv = jnp.linalg.inv(A_ii)
     # A_ie shape (n_cheby_int, n_cheby_bdry)
     A_ie = diff_operator[n_cheby_bdry:, :n_cheby_bdry]
-    L_2 = jnp.zeros((diff_operator.shape[0], n_cheby_bdry), dtype=jnp.float64)
+    L_2 = jnp.zeros((diff_operator.shape[0], n_cheby_bdry), dtype=diff_operator.dtype)
     L_2 = L_2.at[:n_cheby_bdry].set(jnp.eye(n_cheby_bdry))
     soln_operator = -1 * A_ii_inv @ A_ie
     L_2 = L_2.at[n_cheby_bdry:].set(soln_operator)

--- a/src/jaxhps/local_solve/_uniform_2D_DtN.py
+++ b/src/jaxhps/local_solve/_uniform_2D_DtN.py
@@ -257,7 +257,9 @@ def get_DtN(
     A_ii_inv = jnp.linalg.inv(A_ii)
     # A_ie shape (n_cheby_int, n_cheby_bdry)
     A_ie = diff_operator[n_cheby_bdry:, :n_cheby_bdry]
-    L_2 = jnp.zeros((diff_operator.shape[0], n_cheby_bdry), dtype=diff_operator.dtype)
+    L_2 = jnp.zeros(
+        (diff_operator.shape[0], n_cheby_bdry), dtype=diff_operator.dtype
+    )
     L_2 = L_2.at[:n_cheby_bdry].set(jnp.eye(n_cheby_bdry))
     soln_operator = -1 * A_ii_inv @ A_ie
     L_2 = L_2.at[n_cheby_bdry:].set(soln_operator)

--- a/src/jaxhps/local_solve/_uniform_2D_DtN.py
+++ b/src/jaxhps/local_solve/_uniform_2D_DtN.py
@@ -257,14 +257,14 @@ def get_DtN(
     A_ii_inv = jnp.linalg.inv(A_ii)
     # A_ie shape (n_cheby_int, n_cheby_bdry)
     A_ie = diff_operator[n_cheby_bdry:, :n_cheby_bdry]
-    L_2 = jnp.zeros((diff_operator.shape[0], n_cheby_bdry), dtype=jnp.float64)
+    L_2 = jnp.zeros((diff_operator.shape[0], n_cheby_bdry), dtype=diff_operator.dtype)
     L_2 = L_2.at[:n_cheby_bdry].set(jnp.eye(n_cheby_bdry))
     soln_operator = -1 * A_ii_inv @ A_ie
     L_2 = L_2.at[n_cheby_bdry:].set(soln_operator)
     Y = L_2 @ P
     T = Q @ Y
 
-    v = jnp.zeros((diff_operator.shape[0], n_src), dtype=jnp.float64)
+    v = jnp.zeros((diff_operator.shape[0], n_src), dtype=diff_operator.dtype)
     v = v.at[n_cheby_bdry:].set(A_ii_inv @ source_term[n_cheby_bdry:])
     h = Q @ v
 


### PR DESCRIPTION
This fixes an issue where the hardcoded jnp.float64 caused complex arrays (like those in PML layers) to have their imaginary parts truncated in local solve stages.