### PR TITLE
3D ItI solver implementation

### DIFF
--- a/examples/accuracy_check_3D_ItI_merges.py
+++ b/examples/accuracy_check_3D_ItI_merges.py
@@ -1,0 +1,393 @@
+"""Accuracy check for the 3D ItI (Impedance-to-Impedance) merges.
+
+Sweeps over refinement levels ``L`` and polynomial orders ``p`` for two
+manufactured problems with impedance (Robin-type) boundary data and reports
+max-norm relative errors against the analytic solution.
+
+Reproduced from the upstream-author test gist:
+    https://gist.github.com/meliao/9b42e6effe81f6dd1c6decefe7a4db05
+
+Usage
+-----
+    python examples/accuracy_check_3D_ItI_merges.py \
+        --problem_1 --problem_2 --p_vals 4 6 8 --l_vals 1 2
+
+See also
+--------
+``examples/hp_convergence_2D_problems.py`` — the 2D counterpart.
+"""
+
+import argparse
+import logging
+import os
+from abc import ABC, abstractmethod
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jaxhps import (
+    DiscretizationNode3D,
+    Domain,
+    PDEProblem,
+    build_solver,
+    solve,
+)
+
+logging.getLogger("matplotlib").setLevel(logging.WARNING)
+
+jax.config.update("jax_default_device", jax.devices("cpu")[0])
+
+XMIN, XMAX = -0.5, 0.5
+YMIN, YMAX = -0.5, 0.5
+ZMIN, ZMAX = -0.5, 0.5
+
+
+def setup_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--plots_dir",
+        type=str,
+        default="data/examples/accuracy_check_3D_ItI",
+        help="Directory for plot/.npz outputs (created if needed).",
+    )
+    parser.add_argument("--problem_1", action="store_true")
+    parser.add_argument("--problem_2", action="store_true")
+    parser.add_argument(
+        "--p_vals",
+        type=int,
+        nargs="+",
+        default=[4, 6, 8],
+        help="Chebyshev polynomial orders to sweep.",
+    )
+    parser.add_argument(
+        "--l_vals",
+        type=int,
+        nargs="+",
+        default=[1, 2],
+        help="Octree refinement levels to sweep.",
+    )
+    parser.add_argument("--debug", action="store_true")
+    return parser.parse_args()
+
+
+class Problem3DItI(ABC):
+    """Abstract base for 3D ItI accuracy-check problems.
+
+    Subclasses supply the analytic solution, PDE coefficients, and source
+    term; ``run`` handles the (L, p) sweep and error computation.
+    """
+
+    # Impedance parameter — override in subclasses as needed.
+    eta: float = 1.0
+
+    @abstractmethod
+    def soln(self, pts: jax.Array) -> jax.Array:
+        """Analytic solution at points ``pts`` of shape (..., 3)."""
+
+    @abstractmethod
+    def source(self, pts: jax.Array) -> jax.Array:
+        """Source term ``f`` at interior Chebyshev points."""
+
+    @abstractmethod
+    def _dx(self, pts: jax.Array) -> jax.Array:
+        """``du/dx`` at points ``pts``."""
+
+    @abstractmethod
+    def _dy(self, pts: jax.Array) -> jax.Array:
+        """``du/dy`` at points ``pts``."""
+
+    @abstractmethod
+    def _dz(self, pts: jax.Array) -> jax.Array:
+        """``du/dz`` at points ``pts``."""
+
+    def D_xx_coefficients(self, pts: jax.Array) -> jax.Array:
+        return jnp.ones(pts.shape[:-1])
+
+    def D_yy_coefficients(self, pts: jax.Array) -> jax.Array:
+        return jnp.ones(pts.shape[:-1])
+
+    def D_zz_coefficients(self, pts: jax.Array) -> jax.Array:
+        return jnp.ones(pts.shape[:-1])
+
+    def I_coefficients(self, pts: jax.Array) -> jax.Array | None:
+        return None
+
+    def D_x_coefficients(self, pts: jax.Array) -> jax.Array | None:
+        return None
+
+    def D_y_coefficients(self, pts: jax.Array) -> jax.Array | None:
+        return None
+
+    def D_z_coefficients(self, pts: jax.Array) -> jax.Array | None:
+        return None
+
+    def boundary_data(
+        self, boundary_points: jax.Array, root: DiscretizationNode3D
+    ) -> list[jax.Array]:
+        """Impedance data ``du/dn + i*eta*u`` on each of the 6 cube faces.
+
+        Face ordering: x=xmin, x=xmax, y=ymin, y=ymax, z=zmin, z=zmax.
+        """
+        n_per_face = boundary_points.shape[0] // 6
+        f1 = boundary_points[:n_per_face]
+        f2 = boundary_points[n_per_face : 2 * n_per_face]
+        f3 = boundary_points[2 * n_per_face : 3 * n_per_face]
+        f4 = boundary_points[3 * n_per_face : 4 * n_per_face]
+        f5 = boundary_points[4 * n_per_face : 5 * n_per_face]
+        f6 = boundary_points[5 * n_per_face :]
+        return [
+            -self._dx(f1) + 1j * self.eta * self.soln(f1),
+            self._dx(f2) + 1j * self.eta * self.soln(f2),
+            -self._dy(f3) + 1j * self.eta * self.soln(f3),
+            self._dy(f4) + 1j * self.eta * self.soln(f4),
+            -self._dz(f5) + 1j * self.eta * self.soln(f5),
+            self._dz(f6) + 1j * self.eta * self.soln(f6),
+        ]
+
+    def run(self, l_vals: list[int], p_vals: list[int]) -> np.ndarray:
+        """Sweep (L, p) and return a 2-D array of max-norm relative errors."""
+        errors = np.zeros((len(l_vals), len(p_vals)))
+        for i, l in enumerate(l_vals):
+            l = int(l)
+            for j, p in enumerate(p_vals):
+                p = int(p)
+                logging.info(
+                    "Running %s with l=%i, p=%i", type(self).__name__, l, p
+                )
+                root = DiscretizationNode3D(
+                    xmin=XMIN,
+                    xmax=XMAX,
+                    ymin=YMIN,
+                    ymax=YMAX,
+                    zmin=ZMIN,
+                    zmax=ZMAX,
+                )
+                domain = Domain(p=p, q=p - 2, root=root, L=l)
+                pts = domain.interior_points
+
+                pde_problem = PDEProblem(
+                    domain=domain,
+                    D_xx_coefficients=self.D_xx_coefficients(pts),
+                    D_yy_coefficients=self.D_yy_coefficients(pts),
+                    D_zz_coefficients=self.D_zz_coefficients(pts),
+                    D_x_coefficients=self.D_x_coefficients(pts),
+                    D_y_coefficients=self.D_y_coefficients(pts),
+                    D_z_coefficients=self.D_z_coefficients(pts),
+                    I_coefficients=self.I_coefficients(pts),
+                    source=self.source(pts),
+                    use_ItI=True,
+                    eta=self.eta,
+                )
+
+                build_solver(pde_problem)
+                g = self.boundary_data(domain.boundary_points, root)
+                computed_soln = solve(pde_problem, g)
+                expected_soln = self.soln(pts)
+
+                err = float(
+                    np.max(
+                        np.abs(
+                            np.asarray(computed_soln)
+                            - np.asarray(expected_soln)
+                        )
+                    )
+                )
+                nrm = float(np.max(np.abs(np.asarray(expected_soln))))
+                errors[i, j] = err / nrm
+                logging.info(
+                    "%s: l=%i, p=%i, err=%.3e",
+                    type(self).__name__,
+                    l,
+                    p,
+                    errors[i, j],
+                )
+                jax.clear_caches()
+        return errors
+
+
+# ---------------------------------------------------------------------------
+# Problem 1 — polynomial coefficients, polynomial solution.
+# ---------------------------------------------------------------------------
+
+
+class Problem1(Problem3DItI):
+    """Operator: ``Delta u + x * u_x + 3 z^2 * u_z = f``.
+
+    Solution ``u = 4 x^3 y^4 z - z^2 + 4 y`` is a polynomial of degree 8
+    that the spectral collocation should resolve to machine precision once
+    ``p`` is large enough.
+    """
+
+    eta = 1.0
+
+    def soln(self, pts):
+        x, y, z = pts[..., 0], pts[..., 1], pts[..., 2]
+        return 4 * x**3 * y**4 * z - z**2 + 4 * y
+
+    def _dx(self, pts):
+        x, y, z = pts[..., 0], pts[..., 1], pts[..., 2]
+        return 12 * x**2 * y**4 * z
+
+    def _dy(self, pts):
+        x, y, z = pts[..., 0], pts[..., 1], pts[..., 2]
+        return 16 * x**3 * y**3 * z + 4
+
+    def _dz(self, pts):
+        x, y, z = pts[..., 0], pts[..., 1], pts[..., 2]
+        return 4 * x**3 * y**4 - 2 * z
+
+    def source(self, pts):
+        x, y, z = pts[..., 0], pts[..., 1], pts[..., 2]
+        # Laplacian: u_xx + u_yy + u_zz
+        term1 = 24 * x * y**4 * z  # u_xx of 4 x^3 y^4 z
+        term2 = 48 * x**3 * y**2 * z  # u_yy of 4 x^3 y^4 z
+        term3 = -2  # u_zz of -z^2
+        # x * u_x
+        term4 = 12 * x**3 * y**4 * z
+        # 3 z^2 * u_z
+        term5 = 12 * x**3 * y**4 * z**2
+        term6 = -6 * z**3
+        return term1 + term2 + term3 + term4 + term5 + term6
+
+    def D_x_coefficients(self, pts):
+        return pts[..., 0]
+
+    def D_z_coefficients(self, pts):
+        return 3 * pts[..., 2] ** 2
+
+
+# ---------------------------------------------------------------------------
+# Problem 2 — Gravity Helmholtz; solution is a plane wave.
+# ---------------------------------------------------------------------------
+
+
+class Problem2(Problem3DItI):
+    """``Delta u + (1 - z) * eta^2 * u = -z * eta^2 * u``, plane-wave solution.
+
+    Solution ``u = exp(i * eta * d . x)`` with direction
+    ``d = (1, 1, 1) / sqrt(3)``. With ``eta = 16`` the plane wave oscillates
+    roughly five times across the unit cube, which probes the solver's
+    high-wavenumber accuracy at modest ``p`` / ``L``.
+    """
+
+    eta = 16.0
+    source_dir = jnp.array([1.0, 1.0, 1.0]) / jnp.sqrt(3)
+
+    def soln(self, pts):
+        return jnp.exp(1j * self.eta * pts @ self.source_dir)
+
+    def source(self, pts):
+        z = pts[..., 2]
+        return -z * self.eta**2 * self.soln(pts)
+
+    def I_coefficients(self, pts):
+        z = pts[..., 2]
+        return (1 - z) * self.eta**2
+
+    def _dx(self, pts):
+        return 1j * self.eta * self.source_dir[0] * self.soln(pts)
+
+    def _dy(self, pts):
+        return 1j * self.eta * self.source_dir[1] * self.soln(pts)
+
+    def _dz(self, pts):
+        return 1j * self.eta * self.source_dir[2] * self.soln(pts)
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def save_results(
+    errors: np.ndarray,
+    l_vals: list[int],
+    p_vals: list[int],
+    name: str,
+    plots_dir: str,
+) -> None:
+    """Save the error grid to ``<plots_dir>/<name>.npz`` (creates dir)."""
+    os.makedirs(plots_dir, exist_ok=True)
+    out = os.path.join(plots_dir, f"{name}.npz")
+    np.savez(
+        out, errors=errors, l_vals=np.array(l_vals), p_vals=np.array(p_vals)
+    )
+    logging.info("Wrote %s", out)
+
+
+def maybe_plot(
+    errors: np.ndarray,
+    l_vals: list[int],
+    p_vals: list[int],
+    title: str,
+    save_path: str | None,
+) -> None:
+    """Plot max-norm relative error vs ``p`` (one curve per ``L``) if matplotlib is available."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        logging.info("matplotlib not available; skipping plot")
+        return
+
+    fig, ax = plt.subplots()
+    for i, l in enumerate(l_vals):
+        ax.semilogy(p_vals, errors[i], marker="o", label=f"L={l}")
+    ax.set_xticks(p_vals)
+    ax.set_xlabel("p")
+    ax.set_ylabel(r"Relative $\ell_{\infty}$ error")
+    ax.legend()
+    ax.grid(True, which="both", linestyle="--", alpha=0.5)
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    if save_path is not None:
+        fig.savefig(save_path, dpi=150)
+        logging.info("Wrote %s", save_path)
+    plt.close(fig)
+
+
+def main() -> None:
+    args = setup_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    if not (args.problem_1 or args.problem_2):
+        # Default: run both.
+        args.problem_1 = args.problem_2 = True
+
+    if args.problem_1:
+        e = Problem1().run(args.l_vals, args.p_vals)
+        print("\nProblem1 errors (rows=L, cols=p):")
+        print(
+            np.array2string(e, formatter={"float_kind": lambda x: f"{x:.3e}"})
+        )
+        save_results(e, args.l_vals, args.p_vals, "problem_1", args.plots_dir)
+        maybe_plot(
+            e,
+            args.l_vals,
+            args.p_vals,
+            "Problem 1: variable-coefficient polynomial",
+            os.path.join(args.plots_dir, "problem_1.png"),
+        )
+
+    if args.problem_2:
+        e = Problem2().run(args.l_vals, args.p_vals)
+        print("\nProblem2 errors (rows=L, cols=p):")
+        print(
+            np.array2string(e, formatter={"float_kind": lambda x: f"{x:.3e}"})
+        )
+        save_results(e, args.l_vals, args.p_vals, "problem_2", args.plots_dir)
+        maybe_plot(
+            e,
+            args.l_vals,
+            args.p_vals,
+            "Problem 2: gravity Helmholtz plane wave",
+            os.path.join(args.plots_dir, "problem_2.png"),
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jaxhps/_build_solver.py
+++ b/src/jaxhps/_build_solver.py
@@ -17,6 +17,7 @@ from .local_solve import (
     local_solve_stage_uniform_2D_DtN,
     local_solve_stage_uniform_2D_ItI,
     local_solve_stage_uniform_3D_DtN,
+    local_solve_stage_uniform_3D_ItI,
     nosource_local_solve_stage_uniform_2D_ItI,
     nosource_local_solve_stage_uniform_2D_DtN,
 )
@@ -27,6 +28,7 @@ from .merge import (
     merge_stage_uniform_2D_DtN,
     merge_stage_uniform_2D_ItI,
     merge_stage_uniform_3D_DtN,
+    merge_stage_uniform_3D_ItI,
     nosource_merge_stage_uniform_2D_ItI,
     nosource_merge_stage_uniform_2D_DtN,
 )
@@ -99,11 +101,14 @@ def build_solver(
             compute_device=compute_device,
             host_device=host_device,
         )
-    if pde_problem.use_ItI:
+    if pde_problem.use_ItI and pde_problem.domain.bool_2D:
         local_solve_fn = local_solve_stage_uniform_2D_ItI
         merge_fn = merge_stage_uniform_2D_ItI
         chunksize_fn = local_solve_chunksize_2D
-
+    elif pde_problem.use_ItI and not pde_problem.domain.bool_2D:
+        local_solve_fn = local_solve_stage_uniform_3D_ItI
+        merge_fn = merge_stage_uniform_3D_ItI
+        chunksize_fn = local_solve_chunksize_3D
     elif pde_problem.domain.bool_uniform and pde_problem.domain.bool_2D:
         local_solve_fn = local_solve_stage_uniform_2D_DtN
         merge_fn = merge_stage_uniform_2D_DtN

--- a/src/jaxhps/_pdeproblem.py
+++ b/src/jaxhps/_pdeproblem.py
@@ -18,6 +18,10 @@ from ._precompute_operators_3D import (
     precompute_P_3D_DtN,
     precompute_Q_3D_DtN,
     precompute_projection_ops_3D,
+    precompute_N_matrix_3D,
+    precompute_N_tilde_matrix_3D,
+    precompute_G_3D_ItI,
+    precompute_QH_3D_ItI,
 )
 from typing import List, Tuple
 
@@ -48,10 +52,14 @@ class PDEProblem:
         if isinstance(domain.root, DiscretizationNode3D):
             bool_2D = False
 
-            # 3D code doesn't support ItI merges
-            if use_ItI:
+            # 3D ItI merges are only supported on uniform octrees in this WIP
+            # implementation. The local solve stage and ItI precomputed operators
+            # are wired up in :mod:`jaxhps.local_solve._uniform_3D_ItI` and
+            # :mod:`jaxhps._precompute_operators_3D`. Adaptive 3D ItI is not yet
+            # implemented.
+            if use_ItI and not domain.bool_uniform:
                 raise NotImplementedError(
-                    "ItI merges are not supported for 3D problems."
+                    "3D ItI merges are only supported for uniform octrees."
                 )
         else:
             bool_2D = True
@@ -68,10 +76,10 @@ class PDEProblem:
         if use_ItI and eta is None:
             raise ValueError("eta must be specified when using ItI merges.")
 
-        # If ItI is being used, it must be a uniform 2D problem
+        # If ItI is being used, it must be a uniform problem
         if use_ItI and not domain.bool_uniform:
             raise ValueError(
-                "ItI merges are only supported for uniform 2D problems."
+                "ItI merges are only supported for uniform problems."
             )
 
         # If it's not a uniform 2D problem, the source must be specified
@@ -207,10 +215,26 @@ class PDEProblem:
             ) = precompute_diff_operators_3D(
                 p=domain.p, half_side_len=half_side_len
             )
-            self.P = precompute_P_3D_DtN(domain.p, domain.q)
-            self.Q = precompute_Q_3D_DtN(
-                domain.p, domain.q, self.D_x, self.D_y, self.D_z
-            )
+            if not use_ItI:
+                self.P = precompute_P_3D_DtN(domain.p, domain.q)
+                self.Q = precompute_Q_3D_DtN(
+                    domain.p, domain.q, self.D_x, self.D_y, self.D_z
+                )
+            else:
+                # Interpolation / Differentiation matrices for 3D ItI merges.
+                # Same naming convention as the 2D case (P, G, QH).  In 3D the
+                # Gauss -> Cheby boundary interpolation `P` is the same for
+                # DtN and ItI (purely geometric averaging at shared
+                # edges/corners), so we reuse the DtN constructor here.
+                self.P = precompute_P_3D_DtN(domain.p, domain.q)
+                N_tilde = precompute_N_tilde_matrix_3D(
+                    self.D_x, self.D_y, self.D_z, domain.p
+                )
+                self.G = precompute_G_3D_ItI(N_tilde, self.eta)
+                N = precompute_N_matrix_3D(
+                    self.D_x, self.D_y, self.D_z, domain.p
+                )
+                self.QH = precompute_QH_3D_ItI(N, domain.p, domain.q, self.eta)
 
             # For adaptive case, we need to precompute projection ops
             if not domain.bool_uniform:

--- a/src/jaxhps/_precompute_operators_3D.py
+++ b/src/jaxhps/_precompute_operators_3D.py
@@ -548,3 +548,186 @@ def indexing_for_refinement_operator(p: int) -> jnp.array:
     )
 
     return row_idxes, col_idxes
+
+
+############################################
+# 3D ItI precomputed operators.
+#
+# Conventions (mirroring the 2D ItI implementation in _precompute_operators_2D.py):
+#  - The Cheby boundary nodes are single-counted: shape (p**3 - (p-2)**3,).
+#  - At edges shared by 2 faces and corners shared by 3 faces, all face
+#    contributions are averaged.  This averaging is purely geometric, so the
+#    Gauss -> Cheby boundary interpolation `P` is the same as in the DtN case
+#    -- the ItI local solve calls :func:`precompute_P_3D_DtN` directly
+#    (unlike 2D, where the ItI variant drops the duplicated Cheby corner row
+#    instead of averaging).
+#  - Outgoing impedance traces live on the 6q**2 Gauss boundary nodes; the QH
+#    operator first builds a double-counted (6 p**2 row) impedance map on the
+#    Cheby boundary and then interpolates Cheby -> Gauss face-wise via
+#    Q_I = kron(I_6, Q_2D).
+############################################
+
+
+@partial(jax.jit, static_argnums=(3,))
+def precompute_N_matrix_3D(
+    du_dx: jnp.ndarray, du_dy: jnp.ndarray, du_dz: jnp.ndarray, p: int
+) -> jnp.ndarray:
+    """Outward-normal-derivative operator on the **double-counted** 6 p**2 Cheby
+    boundary nodes. Returns a matrix of shape (6 p**2, p**3) which maps a
+    function on all p**3 Chebyshev points to its outward normal derivative on
+    each of the 6 faces, taking the values at edges/corners independently per
+    face (so each shared point appears once per face that contains it).
+
+    This matches the inner construction of :func:`precompute_Q_3D_DtN`.
+    """
+    N = jnp.zeros((6 * p**2, p**3), dtype=du_dx.dtype)
+    f1 = get_face_1_idxes(p)
+    f2 = get_face_2_idxes(p)
+    f3 = get_face_3_idxes(p)
+    f4 = get_face_4_idxes(p)
+    f5 = get_face_5_idxes(p)
+    f6 = get_face_6_idxes(p)
+    N = N.at[: p**2].set(-1 * du_dx[f1])
+    N = N.at[p**2 : 2 * p**2].set(du_dx[f2])
+    N = N.at[2 * p**2 : 3 * p**2].set(-1 * du_dy[f3])
+    N = N.at[3 * p**2 : 4 * p**2].set(du_dy[f4])
+    N = N.at[4 * p**2 : 5 * p**2].set(-1 * du_dz[f5])
+    N = N.at[5 * p**2 :].set(du_dz[f6])
+    return N
+
+
+@partial(jax.jit, static_argnums=(3,))
+def precompute_N_tilde_matrix_3D(
+    du_dx: jnp.ndarray, du_dy: jnp.ndarray, du_dz: jnp.ndarray, p: int
+) -> jnp.ndarray:
+    """Outward-normal-derivative operator on the **single-counted** boundary
+    Cheby nodes, with averaging at shared edges and corners.
+
+    Returns a matrix of shape (p**3 - (p-2)**3, p**3).
+
+    For each face f, the rows of N_tilde indexed by ``get_face_X_idxes(p)`` are
+    incremented by the outward-normal contribution from that face. After all
+    six faces have contributed, the rows corresponding to the 8 cube corners
+    are divided by 3 (each corner is touched by 3 faces) and the rows
+    corresponding to the 12 cube edges (each of length p-2) are divided by 2.
+    Interior face rows already have a single contribution.
+    """
+    n_bdry = p**3 - (p - 2) ** 3
+    N_tilde = jnp.zeros((n_bdry, p**3), dtype=du_dx.dtype)
+
+    f1 = get_face_1_idxes(p)
+    f2 = get_face_2_idxes(p)
+    f3 = get_face_3_idxes(p)
+    f4 = get_face_4_idxes(p)
+    f5 = get_face_5_idxes(p)
+    f6 = get_face_6_idxes(p)
+
+    # The columns of du_d* are the rearranged-Cheby-ordering Cheby points;
+    # rows of du_d* are the same ordering. ``get_face_*_idxes`` produces
+    # boundary-Cheby indices in this rearranged ordering.
+    N_tilde = N_tilde.at[f1].add(-1 * du_dx[f1])
+    N_tilde = N_tilde.at[f2].add(du_dx[f2])
+    N_tilde = N_tilde.at[f3].add(-1 * du_dy[f3])
+    N_tilde = N_tilde.at[f4].add(du_dy[f4])
+    N_tilde = N_tilde.at[f5].add(-1 * du_dz[f5])
+    N_tilde = N_tilde.at[f6].add(du_dz[f6])
+
+    # 8 corners (each shared by 3 faces) -> divide by 3.
+    corner_idxes = jnp.array(
+        [
+            0,
+            p - 1,
+            p**2 - p,
+            p**2 - 1,
+            p**2,
+            p**2 + p - 1,
+            2 * p**2 - p,
+            2 * p**2 - 1,
+        ]
+    )
+    N_tilde = N_tilde.at[corner_idxes, :].set(N_tilde[corner_idxes, :] / 3)
+
+    # 12 edges (each shared by 2 faces, length p-2 after corners removed).
+    edge_idxes = jnp.concatenate(
+        [
+            jnp.arange(1, p - 1),
+            jnp.arange(p**2 + 1, p**2 + p - 1),
+            jnp.arange(p**2 - p + 1, p**2 - 1),
+            jnp.arange(2 * p**2 - p + 1, 2 * p**2 - 1),
+            jnp.arange(1, p - 1) * p,
+            jnp.arange(p, p**2 - p, p) + p**2,
+            jnp.arange(2 * p**2, 3 * p**2 - 2 * p, p),
+            jnp.arange(3 * p**2 - 2 * p, 4 * p**2 - 4 * p, p),
+            jnp.arange(2 * p - 1, p**2 - p, p),
+            jnp.arange(p**2 + 2 * p - 1, 2 * p**2 - p, p),
+            jnp.arange(2 * p**2 + p - 1, 3 * p**2 - 2 * p, p),
+            jnp.arange(3 * p**2 - 2 * p + p - 1, 4 * p**2 - 4 * p, p),
+        ]
+    )
+    N_tilde = N_tilde.at[edge_idxes, :].set(N_tilde[edge_idxes, :] / 2)
+
+    return N_tilde
+
+
+@jax.jit
+def precompute_G_3D_ItI(N_tilde: jnp.ndarray, eta: float) -> jnp.ndarray:
+    """Incoming-impedance operator on the single-counted Cheby boundary.
+
+    G = N_tilde + i*eta * I[:n_bdry]   (added to the first n_bdry columns).
+
+    Returns shape (n_bdry, p**3) where n_bdry = p**3 - (p-2)**3. Acts on a
+    solution u on the rearranged Chebyshev grid (boundary first, then interior)
+    and returns the incoming impedance trace ``u_n + i*eta*u`` at each
+    single-counted boundary Cheby node.
+    """
+    shape_0 = N_tilde.shape[0]
+    F = N_tilde.astype(jnp.complex128)
+    F = F.at[:shape_0, :shape_0].set(
+        F[:shape_0, :shape_0] + 1j * eta * jnp.eye(shape_0)
+    )
+    return F
+
+
+@partial(jax.jit, static_argnums=(1, 2))
+def precompute_QH_3D_ItI(
+    N: jnp.ndarray, p: int, q: int, eta: float
+) -> jnp.ndarray:
+    """Outgoing-impedance operator at the 6 q**2 Gauss boundary nodes.
+
+    Builds the double-counted impedance map H = N - i*eta * I_face on the 6 p**2
+    Cheby boundary (i.e. for each face block, subtract i*eta along the diagonal
+    consisting of the columns indexed by that face's Cheby boundary indices).
+    Then interpolates Cheby -> Gauss face-wise using Q_I = kron(I_6, Q_2D).
+
+    Args:
+        N: Output of :func:`precompute_N_matrix_3D`. Shape (6 p**2, p**3).
+        p, q: Shape parameters.
+        eta: Real impedance coefficient.
+
+    Returns:
+        QH: shape (6 q**2, p**3).
+    """
+    H = N.astype(jnp.complex128)
+
+    f1 = get_face_1_idxes(p)
+    f2 = get_face_2_idxes(p)
+    f3 = get_face_3_idxes(p)
+    f4 = get_face_4_idxes(p)
+    f5 = get_face_5_idxes(p)
+    f6 = get_face_6_idxes(p)
+
+    rows = jnp.arange(p**2)
+    H = H.at[rows, f1].add(-1j * eta)
+    H = H.at[rows + p**2, f2].add(-1j * eta)
+    H = H.at[rows + 2 * p**2, f3].add(-1j * eta)
+    H = H.at[rows + 3 * p**2, f4].add(-1j * eta)
+    H = H.at[rows + 4 * p**2, f5].add(-1j * eta)
+    H = H.at[rows + 5 * p**2, f6].add(-1j * eta)
+
+    cheby_pts = chebyshev_points(p)
+    gauss_pts = gauss_points(q)
+    Q = barycentric_lagrange_interpolation_matrix_2D(
+        cheby_pts, cheby_pts, gauss_pts, gauss_pts
+    )
+    Q_I = jnp.kron(jnp.eye(6), Q)
+    return Q_I @ H

--- a/src/jaxhps/_solve.py
+++ b/src/jaxhps/_solve.py
@@ -8,6 +8,7 @@ from .down_pass import (
     down_pass_uniform_2D_ItI,
     down_pass_uniform_2D_DtN,
     down_pass_uniform_3D_DtN,
+    down_pass_uniform_3D_ItI,
     down_pass_adaptive_2D_DtN,
     down_pass_adaptive_3D_DtN,
 )
@@ -74,9 +75,10 @@ def solve(
         # into a single array.
         boundary_data = jnp.concatenate(boundary_data)
 
-    if pde_problem.use_ItI:
+    if pde_problem.use_ItI and pde_problem.domain.bool_2D:
         down_pass_fn = down_pass_uniform_2D_ItI
-
+    elif pde_problem.use_ItI and not pde_problem.domain.bool_2D:
+        down_pass_fn = down_pass_uniform_3D_ItI
     elif pde_problem.domain.bool_2D:
         down_pass_fn = down_pass_uniform_2D_DtN
     else:

--- a/src/jaxhps/down_pass/__init__.py
+++ b/src/jaxhps/down_pass/__init__.py
@@ -2,6 +2,7 @@ from ._uniform_2D_DtN import down_pass_uniform_2D_DtN
 from ._adaptive_2D_DtN import down_pass_adaptive_2D_DtN
 from ._uniform_2D_ItI import down_pass_uniform_2D_ItI
 from ._uniform_3D_DtN import down_pass_uniform_3D_DtN
+from ._uniform_3D_ItI import down_pass_uniform_3D_ItI
 from ._adaptive_3D_DtN import down_pass_adaptive_3D_DtN
 
 __all__ = [
@@ -9,5 +10,6 @@ __all__ = [
     "down_pass_adaptive_2D_DtN",
     "down_pass_uniform_2D_ItI",
     "down_pass_uniform_3D_DtN",
+    "down_pass_uniform_3D_ItI",
     "down_pass_adaptive_3D_DtN",
 ]

--- a/src/jaxhps/down_pass/_uniform_3D_ItI.py
+++ b/src/jaxhps/down_pass/_uniform_3D_ItI.py
@@ -1,0 +1,341 @@
+"""3D ItI down-pass for uniform octrees.
+
+This file mirrors the structure of ``_uniform_2D_ItI.py`` but for the 3D
+oct-merge case.  The merge stage in ``merge/_uniform_3D_ItI.py`` produces
+two outputs per level:
+
+* ``S``, the propagation operator that maps the merged-node's incoming
+  impedance trace ``g_in_ext`` to the interior-face traces ``t_int``
+  (via ``t_int_homog = S @ g_in_ext``).
+* ``g_tilde_int``, the source-only contribution to ``t_int``
+  (``t_int = t_int_homog + g_tilde_int``).
+
+The down-pass walks the octree from the root to the leaves.  At each
+level it:
+
+1. Computes ``t_int = S @ bdry_data + g_tilde_int``.
+2. Splits ``bdry_data`` (24 face-quads) and ``t_int``
+   (24 interior-face-quads) into the boundary-data inputs for the eight
+   children.
+
+The convention used in the 3D ItI merge matches the 2D ItI convention:
+an interior-trace label ``"X_f"`` in ``t_int`` denotes the slot that
+stores ``g_in_X(f)`` -- the incoming-impedance data that leaf ``X``
+needs at its face ``f``.  Compare the 2D ItI down-pass, where
+``t_a_5 = t_int[:n_child]`` is similarly ``g_in_a(5)`` (a's incoming
+at edge 5).
+
+For example, ``t_int[g1(0)] = g_in_a(9)`` is the data leaf ``a`` needs
+as its incoming impedance on face 9, the a-b interface.  By impedance
+compatibility ``u^(b)_9 + g_in_a(9) = 0`` along that interface, this is
+the same as ``-u^(b)_9``.
+
+Both sides of an interior face use the same intra-face 2D ordering, so
+no per-face flip is required.  Contrast 2D ItI, which applies
+``jnp.flipud`` to every other slice of ``t_int`` because neighbouring
+leaves traverse a shared edge in opposite directions under their
+counter-clockwise boundary order.  In 3D the q-by-q Gauss grid on each
+cube face is laid out in the cube's global ``(x, y, z)`` frame and is
+identical for both incident leaves, so each interior-face slice is fed
+in unchanged.
+"""
+
+from typing import List
+
+import jax
+import jax.numpy as jnp
+import logging
+
+
+def down_pass_uniform_3D_ItI(
+    boundary_data: jax.Array,
+    S_lst: List[jax.Array],
+    g_tilde_lst: List[jax.Array],
+    Y_arr: jax.Array,
+    v_arr: jax.Array,
+    device: jax.Device = jax.devices()[0],
+    host_device: jax.Device = jax.devices("cpu")[0],
+) -> jax.Array:
+    """Downward pass for 3D ItI on a uniform octree.
+
+    Parameters
+    ----------
+    boundary_data : jax.Array
+        Incoming impedance data on the merged-domain exterior, in
+        face-quad order (24 face-quads of ``n_per_face`` entries each at
+        the root level).  Shape ``(n_bdry,)`` or ``(n_bdry, n_src)``.
+    S_lst : List[jax.Array]
+        Per-level propagation operators ``S``.  ``S_lst[0]`` is the
+        per-leaf-parent merge (level just above the leaves) and
+        ``S_lst[-1]`` is the root.
+    g_tilde_lst : List[jax.Array]
+        Per-level source-only interior data ``g_tilde``.
+    Y_arr : jax.Array
+        Per-leaf interior-from-boundary maps, shape
+        ``(n_leaf, p**3, 6 * q**2)``.  If ``None``, the function returns
+        the per-leaf incoming impedance traces instead.
+    v_arr : jax.Array
+        Per-leaf particular solution at the interior nodes,
+        ``(n_leaf, p**3)`` or ``(n_leaf, p**3, n_src)``.
+
+    Returns
+    -------
+    jax.Array
+        Per-leaf interior solutions, shape ``(n_leaf, p**3)`` or
+        ``(n_leaf, p**3, n_src)``.
+    """
+    logging.debug(
+        "down_pass_uniform_3D_ItI: started. boundary_imp_data shape: %s, "
+        "len(g_tilde_lst): %s, len(S_lst): %s",
+        boundary_data.shape,
+        len(g_tilde_lst),
+        len(S_lst),
+    )
+
+    bdry_data = jax.device_put(boundary_data, device)
+    if Y_arr is not None:
+        Y_arr = jax.device_put(Y_arr, device)
+    if v_arr is not None:
+        v_arr = jax.device_put(v_arr, device)
+    S_lst = [jax.device_put(S, device) for S in S_lst]
+    g_tilde_lst = [jax.device_put(g_tilde, device) for g_tilde in g_tilde_lst]
+
+    n_levels = len(S_lst)
+
+    bool_multi_source = len(g_tilde_lst) and g_tilde_lst[0].ndim == 3
+    if bool_multi_source and bdry_data.ndim == 1:
+        raise ValueError(
+            "For multi-source downward pass, need to specify boundary"
+            " data for each source."
+        )
+
+    # Reshape to (1, n_bdry) or (1, n_bdry, n_src)
+    if (bool_multi_source and bdry_data.ndim == 2) or (
+        not bool_multi_source and bdry_data.ndim == 1
+    ):
+        bdry_data = jnp.expand_dims(bdry_data, axis=0)
+
+    # Walk the octree from the root down to the leaves.  At each level
+    # we propagate (S, bdry_data, g_tilde) -> 8 children's bdry_data.
+    for level in range(n_levels - 1, -1, -1):
+        S_arr = S_lst[level]
+        g_tilde = g_tilde_lst[level]
+
+        bdry_data = vmapped_propogate_down_3D_ItI(S_arr, bdry_data, g_tilde)
+
+        # Output shape from vmap: (n_parent_at_level, 8, 6 * n_per_face[, n_src])
+        # Flatten the (n_parent, 8) axes for the next level.
+        if bool_multi_source:
+            n_bdry_child = bdry_data.shape[2]
+            n_src = bdry_data.shape[-1]
+            bdry_data = bdry_data.reshape((-1, n_bdry_child, n_src))
+        else:
+            n_bdry_child = bdry_data.shape[2]
+            bdry_data = bdry_data.reshape((-1, n_bdry_child))
+
+    leaf_incoming_imp = bdry_data
+
+    if Y_arr is None:
+        return leaf_incoming_imp
+
+    if bool_multi_source:
+        leaf_homog = jnp.einsum("ijk,ikl->ijl", Y_arr, leaf_incoming_imp)
+    else:
+        leaf_homog = jnp.einsum("ijk,ik->ij", Y_arr, leaf_incoming_imp)
+
+    leaf_solns = leaf_homog + v_arr
+    leaf_solns = jax.device_put(leaf_solns, host_device)
+    return leaf_solns
+
+
+@jax.jit
+def _propogate_down_3D_ItI(
+    S_arr: jax.Array,
+    bdry_data: jax.Array,
+    f_data: jax.Array,
+) -> jax.Array:
+    """Propagate impedance data one level down for a single oct-merge.
+
+    Args
+    ----
+    S_arr : (24 * n_per_face, 24 * n_per_face)
+    bdry_data : (24 * n_per_face,) or (24 * n_per_face, n_src)
+    f_data : (24 * n_per_face,) or (24 * n_per_face, n_src)
+
+    Returns
+    -------
+    jax.Array
+        Shape (8, 6 * n_per_face[, n_src]).  Each child's outer-face
+        boundary data, in leaf-local face order
+        ``[face_0, face_1, face_2, face_3, face_4, face_5]``.
+    """
+    n_per_face = bdry_data.shape[0] // 24
+    n = n_per_face
+
+    # t_int has 24 interior face-quad blocks, organised as
+    #   [Group 1 (12 blocks), Group 2 (12 blocks)]
+    # Group 1 = g_in slots for even-parity receivers (a, c, f, h):
+    #   a_9, c_10, f_18, c_11, a_12, h_20, f_13, h_16, a_17, f_14, h_15, c_19
+    # Group 2 = g_in slots for odd-parity receivers (b, d, e, g):
+    #   b_9, d_12, e_17, b_10, d_11, g_19, e_13, g_14, b_18, g_15, e_16, d_20
+    # See merge/_uniform_3D_ItI.py docstring for details.
+    t_int_homog = S_arr @ bdry_data
+    t_int = t_int_homog + f_data
+
+    n_g1 = 12 * n  # offset where G2 begins
+
+    def pf(f: int, q: int) -> jax.Array:
+        """Parent face f, quad q -> a single n_per_face block."""
+        s = (4 * f + q) * n
+        return bdry_data[s : s + n]
+
+    def t_g1(i: int) -> jax.Array:
+        return t_int[i * n : (i + 1) * n]
+
+    def t_g2(i: int) -> jax.Array:
+        return t_int[n_g1 + i * n : n_g1 + (i + 1) * n]
+
+    # ------------------------------------------------------------------
+    # Parent face-quad ordering (from get_rearrange_indices in 3D DtN):
+    #     face 0 (xmin): [e, h, d, a]
+    #     face 1 (xmax): [f, g, c, b]
+    #     face 2 (ymin): [e, f, b, a]
+    #     face 3 (ymax): [h, g, c, d]
+    #     face 4 (zmax): [e, f, g, h]
+    #     face 5 (zmin): [a, b, c, d]
+    #
+    # Each leaf alpha owns 3 outer faces (in leaf-local
+    # [0=xmin, 1=xmax, 2=ymin, 3=ymax, 4=zmax, 5=zmin] order) and 3
+    # interior faces.  For the interior faces, the value we feed leaf
+    # alpha at face f is g_in_alpha(f).  Under the 2D-style receiver
+    # convention, this is the t_int slot labelled ``"alpha_f"`` -- which
+    # is in Group 1 for even alpha (a, c, f, h) and in Group 2 for odd
+    # alpha (b, d, e, g).
+    # ------------------------------------------------------------------
+
+    # Leaf a (0,0,0): outer={0,2,5}, interior={1=face 9 (a<->b),
+    #                                          3=face 12 (a<->d),
+    #                                          4=face 17 (a<->e)}
+    g_a = jnp.concatenate(
+        [
+            pf(0, 3),  # face 0 xmin
+            t_g1(0),  # face 1 xmax  = g_in_a(9)  = "a_9"
+            pf(2, 3),  # face 2 ymin
+            t_g1(4),  # face 3 ymax  = g_in_a(12) = "a_12"
+            t_g1(8),  # face 4 zmax  = g_in_a(17) = "a_17"
+            pf(5, 0),  # face 5 zmin
+        ],
+        axis=0,
+    )
+
+    # Leaf b (1,0,0): outer={1,2,5}, interior={0=face 9 (b<->a),
+    #                                          3=face 10 (b<->c),
+    #                                          4=face 18 (b<->f)}
+    g_b = jnp.concatenate(
+        [
+            t_g2(0),  # face 0 xmin = g_in_b(9)  = "b_9"
+            pf(1, 3),  # face 1 xmax
+            pf(2, 2),  # face 2 ymin
+            t_g2(3),  # face 3 ymax = g_in_b(10) = "b_10"
+            t_g2(8),  # face 4 zmax = g_in_b(18) = "b_18"
+            pf(5, 1),  # face 5 zmin
+        ],
+        axis=0,
+    )
+
+    # Leaf c (1,1,0): outer={1,3,5}, interior={0=face 11 (c<->d),
+    #                                          2=face 10 (c<->b),
+    #                                          4=face 19 (c<->g)}
+    g_c = jnp.concatenate(
+        [
+            t_g1(3),  # face 0 xmin = g_in_c(11) = "c_11"
+            pf(1, 2),  # face 1 xmax
+            t_g1(1),  # face 2 ymin = g_in_c(10) = "c_10"
+            pf(3, 2),  # face 3 ymax
+            t_g1(11),  # face 4 zmax = g_in_c(19) = "c_19"
+            pf(5, 2),  # face 5 zmin
+        ],
+        axis=0,
+    )
+
+    # Leaf d (0,1,0): outer={0,3,5}, interior={1=face 11 (d<->c),
+    #                                          2=face 12 (d<->a),
+    #                                          4=face 20 (d<->h)}
+    g_d = jnp.concatenate(
+        [
+            pf(0, 2),  # face 0 xmin
+            t_g2(4),  # face 1 xmax = g_in_d(11) = "d_11"
+            t_g2(1),  # face 2 ymin = g_in_d(12) = "d_12"
+            pf(3, 3),  # face 3 ymax
+            t_g2(11),  # face 4 zmax = g_in_d(20) = "d_20"
+            pf(5, 3),  # face 5 zmin
+        ],
+        axis=0,
+    )
+
+    # Leaf e (0,0,1): outer={0,2,4}, interior={1=face 13 (e<->f),
+    #                                          3=face 16 (e<->h),
+    #                                          5=face 17 (e<->a)}
+    g_e = jnp.concatenate(
+        [
+            pf(0, 0),  # face 0 xmin
+            t_g2(6),  # face 1 xmax = g_in_e(13) = "e_13"
+            pf(2, 0),  # face 2 ymin
+            t_g2(10),  # face 3 ymax = g_in_e(16) = "e_16"
+            pf(4, 0),  # face 4 zmax
+            t_g2(2),  # face 5 zmin = g_in_e(17) = "e_17"
+        ],
+        axis=0,
+    )
+
+    # Leaf f (1,0,1): outer={1,2,4}, interior={0=face 13 (f<->e),
+    #                                          3=face 14 (f<->g),
+    #                                          5=face 18 (f<->b)}
+    g_f = jnp.concatenate(
+        [
+            t_g1(6),  # face 0 xmin = g_in_f(13) = "f_13"
+            pf(1, 0),  # face 1 xmax
+            pf(2, 1),  # face 2 ymin
+            t_g1(9),  # face 3 ymax = g_in_f(14) = "f_14"
+            pf(4, 1),  # face 4 zmax
+            t_g1(2),  # face 5 zmin = g_in_f(18) = "f_18"
+        ],
+        axis=0,
+    )
+
+    # Leaf g (1,1,1): outer={1,3,4}, interior={0=face 15 (g<->h),
+    #                                          2=face 14 (g<->f),
+    #                                          5=face 19 (g<->c)}
+    g_g = jnp.concatenate(
+        [
+            t_g2(9),  # face 0 xmin = g_in_g(15) = "g_15"
+            pf(1, 1),  # face 1 xmax
+            t_g2(7),  # face 2 ymin = g_in_g(14) = "g_14"
+            pf(3, 1),  # face 3 ymax
+            pf(4, 2),  # face 4 zmax
+            t_g2(5),  # face 5 zmin = g_in_g(19) = "g_19"
+        ],
+        axis=0,
+    )
+
+    # Leaf h (0,1,1): outer={0,3,4}, interior={1=face 15 (h<->g),
+    #                                          2=face 16 (h<->e),
+    #                                          5=face 20 (h<->d)}
+    g_h = jnp.concatenate(
+        [
+            pf(0, 1),  # face 0 xmin
+            t_g1(10),  # face 1 xmax = g_in_h(15) = "h_15"
+            t_g1(7),  # face 2 ymin = g_in_h(16) = "h_16"
+            pf(3, 0),  # face 3 ymax
+            pf(4, 3),  # face 4 zmax
+            t_g1(5),  # face 5 zmin = g_in_h(20) = "h_20"
+        ],
+        axis=0,
+    )
+
+    return jnp.stack([g_a, g_b, g_c, g_d, g_e, g_f, g_g, g_h], axis=0)
+
+
+vmapped_propogate_down_3D_ItI = jax.vmap(
+    _propogate_down_3D_ItI, in_axes=(0, 0, 0), out_axes=0
+)

--- a/src/jaxhps/local_solve/__init__.py
+++ b/src/jaxhps/local_solve/__init__.py
@@ -2,6 +2,7 @@ from ._uniform_2D_DtN import local_solve_stage_uniform_2D_DtN
 from ._adaptive_2D_DtN import local_solve_stage_adaptive_2D_DtN
 from ._uniform_2D_ItI import local_solve_stage_uniform_2D_ItI
 from ._uniform_3D_DtN import local_solve_stage_uniform_3D_DtN
+from ._uniform_3D_ItI import local_solve_stage_uniform_3D_ItI
 from ._adaptive_3D_DtN import local_solve_stage_adaptive_3D_DtN
 from ._nosource_uniform_2D_DtN import nosource_local_solve_stage_uniform_2D_DtN
 from ._nosource_uniform_2D_ItI import nosource_local_solve_stage_uniform_2D_ItI
@@ -11,6 +12,7 @@ __all__ = [
     "local_solve_stage_adaptive_2D_DtN",
     "local_solve_stage_uniform_2D_ItI",
     "local_solve_stage_uniform_3D_DtN",
+    "local_solve_stage_uniform_3D_ItI",
     "local_solve_stage_adaptive_3D_DtN",
     "nosource_local_solve_stage_uniform_2D_DtN",
     "nosource_local_solve_stage_uniform_2D_ItI",

--- a/src/jaxhps/local_solve/_uniform_3D_ItI.py
+++ b/src/jaxhps/local_solve/_uniform_3D_ItI.py
@@ -1,0 +1,194 @@
+"""3D uniform local solve stage for ItI merges.
+
+Mirrors :mod:`jaxhps.local_solve._uniform_2D_ItI` but for 3D leaves. The
+boundary impedance traces live on a single-counted Cheby boundary
+(``n_bdry = p**3 - (p-2)**3``) for the incoming side, and on the
+``6 q**2`` Gauss boundary for the outgoing side. The local "Robin" problem
+
+.. math::
+   B u = \\begin{pmatrix} G \\\\ A_\\text{int} \\end{pmatrix} u
+       = \\begin{pmatrix} P\\, g_\\text{in} \\\\ f_\\text{int} \\end{pmatrix}
+
+is square (``p**3`` x ``p**3``) and invertible because the ItI map is coercive
+for any kappa, unlike the DtN local Dirichlet solve which can have interior
+resonances.
+
+Operators (precomputed in :mod:`jaxhps._precompute_operators_3D`):
+
+* ``P`` : ``(n_bdry, 6 q**2)`` -- Gauss -> single-counted Cheby boundary.
+* ``QH``: ``(6 q**2, p**3)``    -- Cheby -> outgoing impedance on Gauss boundary.
+* ``G`` : ``(n_bdry, p**3)``    -- incoming impedance ``u_n + i*eta*u`` on Cheby boundary.
+"""
+
+import jax.numpy as jnp
+import jax
+
+from .._pdeproblem import PDEProblem
+from ._uniform_3D_DtN import _gather_coeffs_3D
+from ._uniform_2D_DtN import vmapped_assemble_diff_operator
+from typing import Tuple
+import logging
+
+
+def local_solve_stage_uniform_3D_ItI(
+    pde_problem: PDEProblem,
+    device: jax.Device = jax.devices()[0],
+    host_device: jax.Device = jax.devices("cpu")[0],
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    """Local solve stage for 3D problems with a uniform octree, producing ItI matrices.
+
+    Parameters
+    ----------
+    pde_problem : PDEProblem
+        Specifies the discretization, differential operator, source function,
+        and keeps track of the pre-computed differentiation and interpolation
+        matrices. Must have ``use_ItI=True`` and a 3D uniform domain.
+    device : jax.Device
+        Where to perform the computation.
+    host_device : jax.Device
+        Where to place the output.
+
+    Returns
+    -------
+    Y : jax.Array
+        Solution operators mapping incoming impedance boundary data to
+        homogeneous solutions on the leaf interiors. Shape
+        ``(n_leaves, p**3, 6 q**2)``.
+    T : jax.Array
+        Impedance-to-Impedance matrices for each leaf. Shape
+        ``(n_leaves, 6 q**2, 6 q**2)``.
+    v : jax.Array
+        Particular solutions on the Cheby grid. Shape ``(n_leaves, p**3)`` or
+        ``(n_leaves, p**3, n_src)`` for multi-source.
+    h : jax.Array
+        Outgoing impedance trace ``v_n - i*eta*v`` of the particular solutions.
+        Shape ``(n_leaves, 6 q**2)`` or ``(n_leaves, 6 q**2, n_src)``.
+    """
+    logging.debug(
+        "local_solve_stage_uniform_3D_ItI: started. device=%s", device
+    )
+
+    coeffs_gathered, which_coeffs = _gather_coeffs_3D(
+        D_xx_coeffs=pde_problem.D_xx_coefficients,
+        D_xy_coeffs=pde_problem.D_xy_coefficients,
+        D_yy_coeffs=pde_problem.D_yy_coefficients,
+        D_xz_coeffs=pde_problem.D_xz_coefficients,
+        D_yz_coeffs=pde_problem.D_yz_coefficients,
+        D_zz_coeffs=pde_problem.D_zz_coefficients,
+        D_x_coeffs=pde_problem.D_x_coefficients,
+        D_y_coeffs=pde_problem.D_y_coefficients,
+        D_z_coeffs=pde_problem.D_z_coefficients,
+        I_coeffs=pde_problem.I_coefficients,
+    )
+    source_term = pde_problem.source
+    bool_multi_source = source_term.ndim == 3
+    source_term = jax.device_put(source_term, device)
+
+    # Stack the precomputed differential operators into a single array,
+    # matching the order expected by ``vmapped_assemble_diff_operator``.
+    diff_ops = jnp.stack(
+        [
+            pde_problem.D_xx,
+            pde_problem.D_xy,
+            pde_problem.D_yy,
+            pde_problem.D_xz,
+            pde_problem.D_yz,
+            pde_problem.D_zz,
+            pde_problem.D_x,
+            pde_problem.D_y,
+            pde_problem.D_z,
+            jnp.eye(pde_problem.domain.p**3),
+        ]
+    )
+    diff_ops = jax.device_put(diff_ops, device)
+    coeffs_gathered = jax.device_put(coeffs_gathered, device)
+    diff_operators = vmapped_assemble_diff_operator(
+        coeffs_gathered, which_coeffs, diff_ops
+    )
+    if not bool_multi_source:
+        source_term = jnp.expand_dims(source_term, axis=-1)
+
+    T_arr, Y_arr, h, v = vmapped_get_ItI_3D(
+        diff_operators,
+        source_term,
+        pde_problem.P,
+        pde_problem.QH,
+        pde_problem.G,
+    )
+
+    if not bool_multi_source:
+        h = h[..., 0]
+        v = v[..., 0]
+
+    T_arr_host = jax.device_put(T_arr, host_device)
+    del T_arr
+    v_host = jax.device_put(v, host_device)
+    del v
+    h_host = jax.device_put(h, host_device)
+    del h
+    Y_arr_host = jax.device_put(Y_arr, host_device)
+    del Y_arr
+
+    return Y_arr_host, T_arr_host, v_host, h_host
+
+
+@jax.jit
+def get_ItI_3D(
+    diff_operator: jax.Array,
+    source_term: jax.Array,
+    P: jax.Array,
+    QH: jax.Array,
+    G: jax.Array,
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    """Solve a single 3D leaf's local impedance problem.
+
+    The leaf's PDE is :math:`A u = f` with `A` the assembled differential operator
+    on the ``p**3`` Chebyshev nodes (rearranged so boundary nodes come first).
+    We replace the first ``n_bdry = p**3 - (p-2)**3`` rows of `A` with the
+    incoming-impedance operator `G`, giving a square system
+
+        ``B u = [P @ g_in ; f_int]``
+
+    that is invertible without interior-resonance pathology.
+
+    Args:
+        diff_operator: shape ``(p**3, p**3)``.
+        source_term:   shape ``(p**3, n_src)``.
+        P:             shape ``(n_bdry, 6 q**2)``. Gauss -> Cheby boundary interp.
+        QH:            shape ``(6 q**2, p**3)``. Cheby -> outgoing impedance on Gauss.
+        G:             shape ``(n_bdry, p**3)``. Incoming impedance on Cheby boundary.
+
+    Returns:
+        T:    ``(6 q**2, 6 q**2)``    -- impedance-to-impedance map.
+        Y:    ``(p**3, 6 q**2)``      -- impedance-to-interior solution map.
+        h:    ``(6 q**2, n_src)``     -- outgoing impedance of particular solutions.
+        v:    ``(p**3, n_src)``       -- particular solutions on Cheby grid.
+    """
+    n_cheby_pts = diff_operator.shape[-1]
+    n_bdry = P.shape[0]
+    A = diff_operator
+
+    # Build B by replacing the top n_bdry rows of A with G.
+    B = jnp.zeros((n_cheby_pts, n_cheby_pts), dtype=jnp.complex128)
+    B = B.at[:n_bdry].set(G)
+    B = B.at[n_bdry:].set(A[n_bdry:].astype(jnp.complex128))
+    B_inv = jnp.linalg.inv(B)
+
+    # Phi maps from interior source values to particular solutions on all Cheby nodes.
+    Phi = B_inv[:, n_bdry:]
+
+    # Y maps incoming impedance on Gauss -> homogeneous solution on Cheby.
+    Y = B_inv[:, :n_bdry] @ P
+
+    source_int = source_term[n_bdry:]
+    v = Phi @ source_int
+    h = QH @ v
+    T = QH @ Y
+    return (T, Y, h, v)
+
+
+vmapped_get_ItI_3D = jax.vmap(
+    get_ItI_3D,
+    in_axes=(0, 0, None, None, None),
+    out_axes=(0, 0, 0, 0),
+)

--- a/src/jaxhps/merge/__init__.py
+++ b/src/jaxhps/merge/__init__.py
@@ -2,6 +2,7 @@ from ._uniform_2D_DtN import merge_stage_uniform_2D_DtN
 from ._adaptive_2D_DtN import merge_stage_adaptive_2D_DtN
 from ._uniform_2D_ItI import merge_stage_uniform_2D_ItI
 from ._uniform_3D_DtN import merge_stage_uniform_3D_DtN
+from ._uniform_3D_ItI import merge_stage_uniform_3D_ItI
 from ._adaptive_3D_DtN import merge_stage_adaptive_3D_DtN
 from ._nosource_uniform_2D_DtN import nosource_merge_stage_uniform_2D_DtN
 from ._nosource_uniform_2D_ItI import nosource_merge_stage_uniform_2D_ItI
@@ -11,6 +12,7 @@ __all__ = [
     "merge_stage_adaptive_2D_DtN",
     "merge_stage_uniform_2D_ItI",
     "merge_stage_uniform_3D_DtN",
+    "merge_stage_uniform_3D_ItI",
     "merge_stage_adaptive_3D_DtN",
     "nosource_merge_stage_uniform_2D_DtN",
     "nosource_merge_stage_uniform_2D_ItI",

--- a/src/jaxhps/merge/_uniform_3D_ItI.py
+++ b/src/jaxhps/merge/_uniform_3D_ItI.py
@@ -1,0 +1,1121 @@
+"""3D uniform oct merge stage for ItI matrices.
+
+Mirrors :mod:`jaxhps.merge._uniform_2D_ItI` but for 3D leaves arranged in an
+octree.  Each oct-merge takes 8 sibling leaves (a..h) with their local ItI
+matrices and outgoing-impedance particular sources, and returns the merged
+ItI map plus the propagation operator ``S`` and incoming particular data
+``g_tilde_int`` on the 12 interior face-quadrants needed by the down-pass.
+
+The leaf labelling convention follows :mod:`jaxhps.merge._uniform_3D_DtN`:
+
+*  Bottom layer (z low):  a (0,0,0), b (1,0,0), c (1,1,0), d (0,1,0)
+*  Top layer    (z high): e (0,0,1), f (1,0,1), g (1,1,1), h (0,1,1)
+
+Interior interface labels (the 12 face-quads internal to the octant):
+
+==  ===================  ====================
+nb  interface            shared between
+==  ===================  ====================
+ 9  bottom xz-mid (front)  a <-> b
+10  bottom yz-mid (right)  b <-> c
+11  bottom xz-mid (back)   c <-> d
+12  bottom yz-mid (left)   d <-> a
+13  top xz-mid (front)     e <-> f
+14  top yz-mid (right)     f <-> g
+15  top xz-mid (back)      g <-> h
+16  top yz-mid (left)      h <-> e
+17  vertical front-left    a <-> e
+18  vertical front-right   b <-> f
+19  vertical back-right    c <-> g
+20  vertical back-left     d <-> h
+==  ===================  ====================
+
+For ItI merges we follow the 2D ItI pattern (``merge/_uniform_2D_ItI.py``):
+split the 24 interior unknowns (each interface contributes one g_in trace
+per side) into two groups by "checkerboard" parity of the **receiving**
+leaf at each interface.  Each interface joins one even-parity leaf to one
+odd-parity leaf, so each interface contributes exactly one entry to each
+group.
+
+*  Group 1 (even-parity receivers):  ``a, c, f, h``  -> 12 unknowns
+*  Group 2 (odd-parity receivers):   ``b, d, e, g``  -> 12 unknowns
+
+Naming convention (same as 2D ItI -- in ``down_pass/_uniform_2D_ItI.py``,
+``t_a_5`` stores ``g_in_a(5)``):
+
+*  An interior-trace label ``X_f`` refers to the g_int slot that stores
+   ``g_in_X(f)`` -- leaf ``X`` is the **receiver** at interface ``f``.
+*  An ``h_int`` slot at the corresponding position holds the **other**
+   leaf's outgoing particular data ``h_Y_f`` -- leaf ``Y`` is the
+   **source** whose T-matrices appear in that row of ``D``.
+
+For example, ``g1(0)`` stores ``g_in_a(9)`` (label ``a_9``); the paired
+``h_int`` slot stores ``h_b_9`` (leaf b's outgoing impedance at the
+a-b interface).  The identity coefficient on this row of ``D = I + ...``
+comes from the impedance compatibility ``u^(b)_9 + g_in_a(9) = 0``.
+
+Within each group, slots are ordered by source-leaf groups (b/d/e/g for
+Group 1, a/c/f/h for Group 2) rather than by receiver.  This is a minor
+ordering detail that does not affect correctness; the merge math is the
+same and the planewave test in ``tests/test_merge`` verifies it at
+spectral precision.
+
+The interior block ``D`` of the merge linear system has the structure
+``D = I + [[0, D_12], [D_21, 0]]`` with ``D_12: group 2 -> group 1`` and
+``D_21: group 1 -> group 2``.  This is the structure expected by
+:func:`jaxhps.merge._schur_complement.assemble_merge_outputs_ItI`.
+"""
+
+from typing import Tuple, List
+
+import jax
+import jax.numpy as jnp
+import logging
+
+from ._schur_complement import assemble_merge_outputs_ItI
+from ._uniform_3D_DtN import (
+    get_a_submatrices,
+    get_b_submatrices,
+    get_c_submatrices,
+    get_d_submatrices,
+    get_e_submatrices,
+    get_f_submatrices,
+    get_g_submatrices,
+    get_h_submatrices,
+    get_rearrange_indices,
+)
+
+
+def merge_stage_uniform_3D_ItI(
+    T_arr: jax.Array,
+    h_arr: jax.Array,
+    l: int,
+    device: jax.Device = jax.devices()[0],
+    host_device: jax.Device = jax.devices("cpu")[0],
+    return_T: bool = False,
+) -> Tuple[List[jnp.ndarray], List[jnp.ndarray], List[jnp.ndarray]]:
+    """Implements uniform 3D merges of ItI matrices, eight leaves at a time.
+
+    Mirrors :func:`merge_stage_uniform_3D_DtN` but with the ItI Schur
+    complement structure.
+
+    Parameters
+    ----------
+    T_arr : jax.Array
+        ItI matrices from the local solve stage. Has shape
+        ``(n_leaves, 6 q**2, 6 q**2)`` and dtype ``complex128``.
+
+    h_arr : jax.Array
+        Outgoing-impedance boundary data from the local solve stage. Has
+        shape ``(n_leaves, 6 q**2)`` or ``(n_leaves, 6 q**2, n_src)``.
+
+    l : int
+        Number of levels in the octree.
+
+    Returns
+    -------
+    S_lst : List[jax.Array]
+        Propagation operators per merge level.
+
+    g_tilde_lst : List[jax.Array]
+        Incoming particular data on merge interfaces per level.
+
+    T_last : jax.Array
+        Top-level ItI matrix (only returned if ``return_T=True``).
+    """
+    logging.debug("merge_stage_uniform_3D_ItI: started. device=%s", device)
+
+    T_arr = jax.device_put(T_arr, device)
+    h_arr = jax.device_put(h_arr, device)
+
+    bool_multi_source = h_arr.ndim == 3
+
+    S_lst: List[jnp.ndarray] = []
+    g_tilde_lst: List[jnp.ndarray] = []
+
+    q = int(jnp.sqrt(T_arr.shape[-1] // 6))
+
+    # Add a trailing source axis to h_arr if it isn't there so the vmap
+    # machinery has a uniform shape; we'll squeeze it back at the end.
+    if not bool_multi_source:
+        h_arr = h_arr[..., None]
+
+    for i in range(l - 1, 0, -1):
+        logging.debug("merge_stage_uniform_3D_ItI: i = %d", i)
+        S_arr, T_arr, h_arr, g_tilde_arr = vmapped_uniform_oct_merge_ItI(
+            jnp.arange(q), T_arr, h_arr
+        )
+
+        if not bool_multi_source:
+            g_tilde_arr_out = jnp.squeeze(g_tilde_arr, axis=-1)
+        else:
+            g_tilde_arr_out = g_tilde_arr
+
+        S_lst.append(jax.device_put(S_arr, host_device))
+        g_tilde_lst.append(jax.device_put(g_tilde_arr_out, host_device))
+
+        if host_device != device:
+            S_arr.delete()
+            g_tilde_arr.delete()
+
+    # Final oct-merge without reshaping the outputs.
+    S_last, T_last, h_last, g_tilde_last = _uniform_oct_merge_ItI(
+        jnp.arange(q),
+        T_arr[0],
+        T_arr[1],
+        T_arr[2],
+        T_arr[3],
+        T_arr[4],
+        T_arr[5],
+        T_arr[6],
+        T_arr[7],
+        h_arr[0],
+        h_arr[1],
+        h_arr[2],
+        h_arr[3],
+        h_arr[4],
+        h_arr[5],
+        h_arr[6],
+        h_arr[7],
+    )
+
+    if not bool_multi_source:
+        g_tilde_last = jnp.squeeze(g_tilde_last, axis=-1)
+        h_last = jnp.squeeze(h_last, axis=-1)
+
+    S_lst.append(jax.device_put(jnp.expand_dims(S_last, axis=0), host_device))
+    g_tilde_lst.append(
+        jax.device_put(jnp.expand_dims(g_tilde_last, axis=0), host_device)
+    )
+
+    if return_T:
+        T_last_out = jax.device_put(T_last, host_device)
+        return S_lst, g_tilde_lst, T_last_out
+    return S_lst, g_tilde_lst
+
+
+@jax.jit
+def _uniform_oct_merge_ItI(
+    q_idxes: jnp.ndarray,
+    T_a: jnp.ndarray,
+    T_b: jnp.ndarray,
+    T_c: jnp.ndarray,
+    T_d: jnp.ndarray,
+    T_e: jnp.ndarray,
+    T_f: jnp.ndarray,
+    T_g: jnp.ndarray,
+    T_h: jnp.ndarray,
+    h_a: jnp.ndarray,
+    h_b: jnp.ndarray,
+    h_c: jnp.ndarray,
+    h_d: jnp.ndarray,
+    h_e: jnp.ndarray,
+    h_f: jnp.ndarray,
+    h_g: jnp.ndarray,
+    h_h: jnp.ndarray,
+) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """ItI 8-way oct-merge of sibling leaves.
+
+    Parameters
+    ----------
+    q_idxes : jax.Array
+        Index array used by ``get_rearrange_indices`` for the final
+        leaf-block -> face-quad rearrangement.
+    T_a..T_h : jax.Array (complex128)
+        Local ItI matrices for the 8 children. Shape ``(6 q**2, 6 q**2)``.
+    h_a..h_h : jax.Array (complex128)
+        Local outgoing-impedance particular data. Shape ``(6 q**2,)`` or
+        ``(6 q**2, n_src)``.
+
+    Returns
+    -------
+    S : jax.Array
+        Propagation operator. Shape ``(24 q**2_int, 24 q**2_ext)``.
+    T : jax.Array
+        Merged ItI matrix. Shape ``(24 q**2_ext, 24 q**2_ext)``.
+    h_ext_out : jax.Array
+        Outgoing-impedance particular data on the merged exterior. Shape
+        ``(24 q**2_ext,)`` or ``(24 q**2_ext, n_src)``.
+    g_tilde_int : jax.Array
+        Incoming-impedance particular data on the 12 interior interfaces.
+        Shape ``(24 q**2_int,)`` or ``(24 q**2_int, n_src)``.
+    """
+    # Extract per-leaf submatrices and subvectors. The DtN helpers do
+    # generic indexing and work on complex matrices unchanged.
+    a_sub = get_a_submatrices(T_a, h_a)
+    b_sub = get_b_submatrices(T_b, h_b)
+    c_sub = get_c_submatrices(T_c, h_c)
+    d_sub = get_d_submatrices(T_d, h_d)
+    e_sub = get_e_submatrices(T_e, h_e)
+    f_sub = get_f_submatrices(T_f, h_f)
+    g_sub = get_g_submatrices(T_g, h_g)
+    h_sub = get_h_submatrices(T_h, h_h)
+
+    T, S, h_ext_out, g_tilde_int = _oct_merge_from_submatrices_ItI(
+        a_sub, b_sub, c_sub, d_sub, e_sub, f_sub, g_sub, h_sub
+    )
+
+    r = get_rearrange_indices(jnp.arange(T.shape[0]), q_idxes)
+    h_ext_out = h_ext_out[r]
+    T = T[r][:, r]
+    S = S[:, r]
+
+    return S, T, h_ext_out, g_tilde_int
+
+
+@jax.jit
+def _oct_merge_from_submatrices_ItI(
+    a_sub: Tuple[jax.Array],
+    b_sub: Tuple[jax.Array],
+    c_sub: Tuple[jax.Array],
+    d_sub: Tuple[jax.Array],
+    e_sub: Tuple[jax.Array],
+    f_sub: Tuple[jax.Array],
+    g_sub: Tuple[jax.Array],
+    h_sub: Tuple[jax.Array],
+) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    """Build the ItI Schur-complement system and call ``assemble_merge_outputs_ItI``.
+
+    Each ``*_sub`` tuple has the structure produced by
+    :func:`jaxhps.merge._uniform_3D_DtN._return_submatrices_subvecs`:
+
+    For leaf ``a`` with index sets ``(idx_1, idx_9, idx_12, idx_17)``::
+
+        T_a_1_1, T_a_1_9, T_a_1_12, T_a_1_17,
+        T_a_9_1, T_a_9_9, T_a_9_12, T_a_9_17,
+        T_a_12_1, T_a_12_9, T_a_12_12, T_a_12_17,
+        T_a_17_1, T_a_17_9, T_a_17_12, T_a_17_17,
+        h_a_1, h_a_9, h_a_12, h_a_17
+
+    Other leaves follow the same structure, with their own face indices.
+    """
+    (
+        T_a_1_1,
+        T_a_1_9,
+        T_a_1_12,
+        T_a_1_17,
+        T_a_9_1,
+        T_a_9_9,
+        T_a_9_12,
+        T_a_9_17,
+        T_a_12_1,
+        T_a_12_9,
+        T_a_12_12,
+        T_a_12_17,
+        T_a_17_1,
+        T_a_17_9,
+        T_a_17_12,
+        T_a_17_17,
+        h_a_1,
+        h_a_9,
+        h_a_12,
+        h_a_17,
+    ) = a_sub
+
+    (
+        T_b_2_2,
+        T_b_2_9,
+        T_b_2_10,
+        T_b_2_18,
+        T_b_9_2,
+        T_b_9_9,
+        T_b_9_10,
+        T_b_9_18,
+        T_b_10_2,
+        T_b_10_9,
+        T_b_10_10,
+        T_b_10_18,
+        T_b_18_2,
+        T_b_18_9,
+        T_b_18_10,
+        T_b_18_18,
+        h_b_2,
+        h_b_9,
+        h_b_10,
+        h_b_18,
+    ) = b_sub
+
+    (
+        T_c_3_3,
+        T_c_3_10,
+        T_c_3_11,
+        T_c_3_19,
+        T_c_10_3,
+        T_c_10_10,
+        T_c_10_11,
+        T_c_10_19,
+        T_c_11_3,
+        T_c_11_10,
+        T_c_11_11,
+        T_c_11_19,
+        T_c_19_3,
+        T_c_19_10,
+        T_c_19_11,
+        T_c_19_19,
+        h_c_3,
+        h_c_10,
+        h_c_11,
+        h_c_19,
+    ) = c_sub
+
+    (
+        T_d_4_4,
+        T_d_4_11,
+        T_d_4_12,
+        T_d_4_20,
+        T_d_11_4,
+        T_d_11_11,
+        T_d_11_12,
+        T_d_11_20,
+        T_d_12_4,
+        T_d_12_11,
+        T_d_12_12,
+        T_d_12_20,
+        T_d_20_4,
+        T_d_20_11,
+        T_d_20_12,
+        T_d_20_20,
+        h_d_4,
+        h_d_11,
+        h_d_12,
+        h_d_20,
+    ) = d_sub
+
+    (
+        T_e_5_5,
+        T_e_5_13,
+        T_e_5_16,
+        T_e_5_17,
+        T_e_13_5,
+        T_e_13_13,
+        T_e_13_16,
+        T_e_13_17,
+        T_e_16_5,
+        T_e_16_13,
+        T_e_16_16,
+        T_e_16_17,
+        T_e_17_5,
+        T_e_17_13,
+        T_e_17_16,
+        T_e_17_17,
+        h_e_5,
+        h_e_13,
+        h_e_16,
+        h_e_17,
+    ) = e_sub
+
+    (
+        T_f_6_6,
+        T_f_6_13,
+        T_f_6_14,
+        T_f_6_18,
+        T_f_13_6,
+        T_f_13_13,
+        T_f_13_14,
+        T_f_13_18,
+        T_f_14_6,
+        T_f_14_13,
+        T_f_14_14,
+        T_f_14_18,
+        T_f_18_6,
+        T_f_18_13,
+        T_f_18_14,
+        T_f_18_18,
+        h_f_6,
+        h_f_13,
+        h_f_14,
+        h_f_18,
+    ) = f_sub
+
+    (
+        T_g_7_7,
+        T_g_7_14,
+        T_g_7_15,
+        T_g_7_19,
+        T_g_14_7,
+        T_g_14_14,
+        T_g_14_15,
+        T_g_14_19,
+        T_g_15_7,
+        T_g_15_14,
+        T_g_15_15,
+        T_g_15_19,
+        T_g_19_7,
+        T_g_19_14,
+        T_g_19_15,
+        T_g_19_19,
+        h_g_7,
+        h_g_14,
+        h_g_15,
+        h_g_19,
+    ) = g_sub
+
+    (
+        T_h_8_8,
+        T_h_8_15,
+        T_h_8_16,
+        T_h_8_20,
+        T_h_15_8,
+        T_h_15_15,
+        T_h_15_16,
+        T_h_15_20,
+        T_h_16_8,
+        T_h_16_15,
+        T_h_16_16,
+        T_h_16_20,
+        T_h_20_8,
+        T_h_20_15,
+        T_h_20_16,
+        T_h_20_20,
+        h_h_8,
+        h_h_15,
+        h_h_16,
+        h_h_20,
+    ) = h_sub
+
+    # Per-face block sizes. All face-quads have the same n_per_face = q**2
+    # in the uniform case, but compute them generically.
+    n_1 = T_a_1_1.shape[0]
+    n_2 = T_b_2_2.shape[0]
+    n_3 = T_c_3_3.shape[0]
+    n_4 = T_d_4_4.shape[0]
+    n_5 = T_e_5_5.shape[0]
+    n_6 = T_f_6_6.shape[0]
+    n_7 = T_g_7_7.shape[0]
+    n_8 = T_h_8_8.shape[0]
+    n_9 = T_a_9_9.shape[0]
+    n_10 = T_b_10_10.shape[0]
+    n_11 = T_c_11_11.shape[0]
+    n_12 = T_a_12_12.shape[0]
+    n_13 = T_e_13_13.shape[0]
+    n_14 = T_f_14_14.shape[0]
+    n_15 = T_g_15_15.shape[0]
+    n_16 = T_e_16_16.shape[0]
+    n_17 = T_a_17_17.shape[0]
+    n_18 = T_b_18_18.shape[0]
+    n_19 = T_c_19_19.shape[0]
+    n_20 = T_d_20_20.shape[0]
+
+    n_ext_pts = n_1 + n_2 + n_3 + n_4 + n_5 + n_6 + n_7 + n_8
+
+    # Group 1 (even-parity receivers).  Slots store, in order:
+    #   a_9, c_10, f_18, c_11, a_12, h_20, f_13, h_16, a_17, f_14, h_15, c_19
+    # i.e. for each odd-source leaf (b, d, e, g), the g_in traces at the
+    # three even neighbours across that source's three interior faces.
+    g1_sizes = [
+        n_9,
+        n_10,
+        n_18,  # b-source: a_9, c_10, f_18
+        n_11,
+        n_12,
+        n_20,  # d-source: c_11, a_12, h_20
+        n_13,
+        n_16,
+        n_17,  # e-source: f_13, h_16, a_17
+        n_14,
+        n_15,
+        n_19,  # g-source: f_14, h_15, c_19
+    ]
+    # Use Python int arithmetic so offsets are static (shapes are known
+    # at trace time inside @jax.jit).
+    g1_offsets = [0]
+    for sz in g1_sizes:
+        g1_offsets.append(g1_offsets[-1] + sz)
+    n_g1 = g1_offsets[-1]
+
+    # Group 2 (odd-parity receivers).  Slots store, in order:
+    #   b_9, d_12, e_17, b_10, d_11, g_19, e_13, g_14, b_18, g_15, e_16, d_20
+    # i.e. for each even-source leaf (a, c, f, h), the g_in traces at the
+    # three odd neighbours across that source's three interior faces.
+    g2_sizes = [
+        n_9,
+        n_12,
+        n_17,  # a-source: b_9, d_12, e_17
+        n_10,
+        n_11,
+        n_19,  # c-source: b_10, d_11, g_19
+        n_13,
+        n_14,
+        n_18,  # f-source: e_13, g_14, b_18
+        n_15,
+        n_16,
+        n_20,  # h-source: g_15, e_16, d_20
+    ]
+    g2_offsets = [0]
+    for sz in g2_sizes:
+        g2_offsets.append(g2_offsets[-1] + sz)
+    n_g2 = g2_offsets[-1]
+
+    def g1(i: int) -> Tuple[int, int]:
+        return g1_offsets[i], g1_offsets[i + 1]
+
+    def g2(i: int) -> Tuple[int, int]:
+        return g2_offsets[i], g2_offsets[i + 1]
+
+    # Exterior block offsets.
+    ext_starts = [0]
+    for sz in [n_1, n_2, n_3, n_4, n_5, n_6, n_7, n_8]:
+        ext_starts.append(ext_starts[-1] + sz)
+
+    def ext(i: int) -> Tuple[int, int]:
+        return ext_starts[i], ext_starts[i + 1]
+
+    dtype = T_a_1_1.dtype
+
+    # ------------------------------------------------------------------
+    # Build B (n_ext_pts x (n_g1 + n_g2)).  For each leaf alpha, alpha's
+    # exterior block has nonzero entries at the columns corresponding to
+    # alpha's three incoming-impedance interior traces (g_in_alpha at
+    # alpha's three interior faces).  Even leaves' g_in slots live in
+    # Group 1; odd leaves' g_in slots live in Group 2.
+    # ------------------------------------------------------------------
+    B = jnp.zeros((n_ext_pts, n_g1 + n_g2), dtype=dtype)
+
+    # B[alpha_outer, alpha_g_in_slot] = T_alpha[outer, interior_face]
+    # The g_int slot storing g_in_alpha(f) is in the OPPOSITE parity
+    # group from alpha (even leaves' g_in_* slots are in Group 1, odd
+    # leaves' g_in_* slots are in Group 2).
+
+    # Leaf a (even) -> a's g_in slots live in Group 1.
+    # a's interior faces and the slot that stores g_in_a(f):
+    #   face 9  (a<->b): g1(0) = a_9
+    #   face 12 (a<->d): g1(4) = a_12
+    #   face 17 (a<->e): g1(8) = a_17
+    s, e = ext(0)
+    s1, e1 = g1(0)  # a_9
+    B = B.at[s:e, s1:e1].set(T_a_1_9)
+    s1, e1 = g1(4)  # a_12
+    B = B.at[s:e, s1:e1].set(T_a_1_12)
+    s1, e1 = g1(8)  # a_17
+    B = B.at[s:e, s1:e1].set(T_a_1_17)
+
+    # Leaf b (odd) -> b's g_in slots live in Group 2.
+    # b's interior faces and the slot that stores g_in_b(f):
+    #   face 9  (b<->a): g2(0) = b_9
+    #   face 10 (b<->c): g2(3) = b_10
+    #   face 18 (b<->f): g2(8) = b_18
+    s, e = ext(1)
+    s2, e2 = g2(0)  # b_9
+    B = B.at[s:e, n_g1 + s2 : n_g1 + e2].set(T_b_2_9)
+    s2, e2 = g2(3)  # b_10
+    B = B.at[s:e, n_g1 + s2 : n_g1 + e2].set(T_b_2_10)
+    s2, e2 = g2(8)  # b_18
+    B = B.at[s:e, n_g1 + s2 : n_g1 + e2].set(T_b_2_18)
+
+    # Leaf c (even) -> c's g_in slots live in Group 1.
+    #   face 10 (c<->b): g1(1) = c_10
+    #   face 11 (c<->d): g1(3) = c_11
+    #   face 19 (c<->g): g1(11) = c_19
+    s, e = ext(2)
+    s1, e1 = g1(1)  # c_10
+    B = B.at[s:e, s1:e1].set(T_c_3_10)
+    s1, e1 = g1(3)  # c_11
+    B = B.at[s:e, s1:e1].set(T_c_3_11)
+    s1, e1 = g1(11)  # c_19
+    B = B.at[s:e, s1:e1].set(T_c_3_19)
+
+    # Leaf d (odd) -> d's g_in slots live in Group 2.
+    #   face 11 (d<->c): g2(4) = d_11
+    #   face 12 (d<->a): g2(1) = d_12
+    #   face 20 (d<->h): g2(11) = d_20
+    s, e = ext(3)
+    s2, e2 = g2(4)  # d_11
+    B = B.at[s:e, n_g1 + s2 : n_g1 + e2].set(T_d_4_11)
+    s2, e2 = g2(1)  # d_12
+    B = B.at[s:e, n_g1 + s2 : n_g1 + e2].set(T_d_4_12)
+    s2, e2 = g2(11)  # d_20
+    B = B.at[s:e, n_g1 + s2 : n_g1 + e2].set(T_d_4_20)
+
+    # Leaf e (odd) -> e's g_in slots live in Group 2.
+    #   face 13 (e<->f): g2(6) = e_13
+    #   face 16 (e<->h): g2(10) = e_16
+    #   face 17 (e<->a): g2(2) = e_17
+    s, e = ext(4)
+    s2, e2 = g2(6)  # e_13
+    B = B.at[s:e, n_g1 + s2 : n_g1 + e2].set(T_e_5_13)
+    s2, e2 = g2(10)  # e_16
+    B = B.at[s:e, n_g1 + s2 : n_g1 + e2].set(T_e_5_16)
+    s2, e2 = g2(2)  # e_17
+    B = B.at[s:e, n_g1 + s2 : n_g1 + e2].set(T_e_5_17)
+
+    # Leaf f (even) -> f's g_in slots live in Group 1.
+    #   face 13 (f<->e): g1(6) = f_13
+    #   face 14 (f<->g): g1(9) = f_14
+    #   face 18 (f<->b): g1(2) = f_18
+    s, e = ext(5)
+    s1, e1 = g1(6)  # f_13
+    B = B.at[s:e, s1:e1].set(T_f_6_13)
+    s1, e1 = g1(9)  # f_14
+    B = B.at[s:e, s1:e1].set(T_f_6_14)
+    s1, e1 = g1(2)  # f_18
+    B = B.at[s:e, s1:e1].set(T_f_6_18)
+
+    # Leaf g (odd) -> g's g_in slots live in Group 2.
+    #   face 14 (g<->f): g2(7) = g_14
+    #   face 15 (g<->h): g2(9) = g_15
+    #   face 19 (g<->c): g2(5) = g_19
+    s, e = ext(6)
+    s2, e2 = g2(7)  # g_14
+    B = B.at[s:e, n_g1 + s2 : n_g1 + e2].set(T_g_7_14)
+    s2, e2 = g2(9)  # g_15
+    B = B.at[s:e, n_g1 + s2 : n_g1 + e2].set(T_g_7_15)
+    s2, e2 = g2(5)  # g_19
+    B = B.at[s:e, n_g1 + s2 : n_g1 + e2].set(T_g_7_19)
+
+    # Leaf h (even) -> h's g_in slots live in Group 1.
+    #   face 15 (h<->g): g1(10) = h_15
+    #   face 16 (h<->e): g1(7) = h_16
+    #   face 20 (h<->d): g1(5) = h_20
+    s, e = ext(7)
+    s1, e1 = g1(10)  # h_15
+    B = B.at[s:e, s1:e1].set(T_h_8_15)
+    s1, e1 = g1(7)  # h_16
+    B = B.at[s:e, s1:e1].set(T_h_8_16)
+    s1, e1 = g1(5)  # h_20
+    B = B.at[s:e, s1:e1].set(T_h_8_20)
+
+    # ------------------------------------------------------------------
+    # Build C ((n_g1 + n_g2) x n_ext_pts).  Each row corresponds to the
+    # ItI constraint coming from the SOURCE side of an interior interface
+    # (the side whose h-piece sits in h_int at this row).  The constraint
+    # h_X_f = T_X[interior_f, ext_X] u_ext^(X) + ...  contributes T-blocks
+    # at the columns of the source leaf X's exterior.
+    # ------------------------------------------------------------------
+    C = jnp.zeros((n_g1 + n_g2, n_ext_pts), dtype=dtype)
+
+    # Group 1 rows: sources are b, d, e, g (odd leaves).  Row labels are
+    # the receiver names since this is the row of D corresponding to that
+    # g_int slot, but the T-blocks come from the opposite (source) leaf.
+    s1, e1 = g1(0)
+    s, e = ext(1)
+    C = C.at[s1:e1, s:e].set(T_b_9_2)
+    s1, e1 = g1(1)
+    s, e = ext(1)
+    C = C.at[s1:e1, s:e].set(T_b_10_2)
+    s1, e1 = g1(2)
+    s, e = ext(1)
+    C = C.at[s1:e1, s:e].set(T_b_18_2)
+    s1, e1 = g1(3)
+    s, e = ext(3)
+    C = C.at[s1:e1, s:e].set(T_d_11_4)
+    s1, e1 = g1(4)
+    s, e = ext(3)
+    C = C.at[s1:e1, s:e].set(T_d_12_4)
+    s1, e1 = g1(5)
+    s, e = ext(3)
+    C = C.at[s1:e1, s:e].set(T_d_20_4)
+    s1, e1 = g1(6)
+    s, e = ext(4)
+    C = C.at[s1:e1, s:e].set(T_e_13_5)
+    s1, e1 = g1(7)
+    s, e = ext(4)
+    C = C.at[s1:e1, s:e].set(T_e_16_5)
+    s1, e1 = g1(8)
+    s, e = ext(4)
+    C = C.at[s1:e1, s:e].set(T_e_17_5)
+    s1, e1 = g1(9)
+    s, e = ext(6)
+    C = C.at[s1:e1, s:e].set(T_g_14_7)
+    s1, e1 = g1(10)
+    s, e = ext(6)
+    C = C.at[s1:e1, s:e].set(T_g_15_7)
+    s1, e1 = g1(11)
+    s, e = ext(6)
+    C = C.at[s1:e1, s:e].set(T_g_19_7)
+
+    # Group 2 rows.
+    s2, e2 = g2(0)
+    s, e = ext(0)
+    C = C.at[n_g1 + s2 : n_g1 + e2, s:e].set(T_a_9_1)
+    s2, e2 = g2(1)
+    s, e = ext(0)
+    C = C.at[n_g1 + s2 : n_g1 + e2, s:e].set(T_a_12_1)
+    s2, e2 = g2(2)
+    s, e = ext(0)
+    C = C.at[n_g1 + s2 : n_g1 + e2, s:e].set(T_a_17_1)
+    s2, e2 = g2(3)
+    s, e = ext(2)
+    C = C.at[n_g1 + s2 : n_g1 + e2, s:e].set(T_c_10_3)
+    s2, e2 = g2(4)
+    s, e = ext(2)
+    C = C.at[n_g1 + s2 : n_g1 + e2, s:e].set(T_c_11_3)
+    s2, e2 = g2(5)
+    s, e = ext(2)
+    C = C.at[n_g1 + s2 : n_g1 + e2, s:e].set(T_c_19_3)
+    s2, e2 = g2(6)
+    s, e = ext(5)
+    C = C.at[n_g1 + s2 : n_g1 + e2, s:e].set(T_f_13_6)
+    s2, e2 = g2(7)
+    s, e = ext(5)
+    C = C.at[n_g1 + s2 : n_g1 + e2, s:e].set(T_f_14_6)
+    s2, e2 = g2(8)
+    s, e = ext(5)
+    C = C.at[n_g1 + s2 : n_g1 + e2, s:e].set(T_f_18_6)
+    s2, e2 = g2(9)
+    s, e = ext(7)
+    C = C.at[n_g1 + s2 : n_g1 + e2, s:e].set(T_h_15_8)
+    s2, e2 = g2(10)
+    s, e = ext(7)
+    C = C.at[n_g1 + s2 : n_g1 + e2, s:e].set(T_h_16_8)
+    s2, e2 = g2(11)
+    s, e = ext(7)
+    C = C.at[n_g1 + s2 : n_g1 + e2, s:e].set(T_h_20_8)
+
+    # ------------------------------------------------------------------
+    # Build D_12 (n_g1 x n_g2).  Each row of D_12 corresponds to a Group 1
+    # g_int slot (g_in_alpha(f) for even receiver alpha at interface f);
+    # the T-blocks in that row come from the OPPOSITE (odd) source-leaf
+    # at the same interface.  The Group 2 columns hold the source-leaf's
+    # own three g_in slots, so the row is filled with three T_source[f,j]
+    # blocks.
+    # ------------------------------------------------------------------
+    D_12 = jnp.zeros((n_g1, n_g2), dtype=dtype)
+
+    # Row a_9 (g1 idx 0): source leaf b at iface 9.  b's interior faces
+    # (9, 10, 18) -> b's own g_in slots in Group 2:
+    #   b_9 = g2(0), b_10 = g2(3), b_18 = g2(8).
+    s1, e1 = g1(0)
+    s2, e2 = g2(0)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_b_9_9)
+    s2, e2 = g2(3)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_b_9_10)
+    s2, e2 = g2(8)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_b_9_18)
+
+    # Row c_10 (g1 idx 1): source leaf b at iface 10.
+    s1, e1 = g1(1)
+    s2, e2 = g2(0)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_b_10_9)
+    s2, e2 = g2(3)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_b_10_10)
+    s2, e2 = g2(8)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_b_10_18)
+
+    # Row f_18 (g1 idx 2): source leaf b at iface 18.
+    s1, e1 = g1(2)
+    s2, e2 = g2(0)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_b_18_9)
+    s2, e2 = g2(3)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_b_18_10)
+    s2, e2 = g2(8)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_b_18_18)
+
+    # Row c_11 (g1 idx 3): source leaf d at iface 11.  d's interior faces
+    # (11, 12, 20) -> d's own g_in slots in Group 2:
+    #   d_11 = g2(4), d_12 = g2(1), d_20 = g2(11).
+    s1, e1 = g1(3)
+    s2, e2 = g2(4)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_d_11_11)
+    s2, e2 = g2(1)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_d_11_12)
+    s2, e2 = g2(11)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_d_11_20)
+
+    # Row a_12 (g1 idx 4): source leaf d at iface 12.
+    s1, e1 = g1(4)
+    s2, e2 = g2(4)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_d_12_11)
+    s2, e2 = g2(1)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_d_12_12)
+    s2, e2 = g2(11)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_d_12_20)
+
+    # Row h_20 (g1 idx 5): source leaf d at iface 20.
+    s1, e1 = g1(5)
+    s2, e2 = g2(4)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_d_20_11)
+    s2, e2 = g2(1)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_d_20_12)
+    s2, e2 = g2(11)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_d_20_20)
+
+    # Row f_13 (g1 idx 6): source leaf e at iface 13.  e's interior faces
+    # (13, 16, 17) -> e's own g_in slots in Group 2:
+    #   e_13 = g2(6), e_16 = g2(10), e_17 = g2(2).
+    s1, e1 = g1(6)
+    s2, e2 = g2(6)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_e_13_13)
+    s2, e2 = g2(10)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_e_13_16)
+    s2, e2 = g2(2)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_e_13_17)
+
+    # Row h_16 (g1 idx 7): source leaf e at iface 16.
+    s1, e1 = g1(7)
+    s2, e2 = g2(6)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_e_16_13)
+    s2, e2 = g2(10)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_e_16_16)
+    s2, e2 = g2(2)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_e_16_17)
+
+    # Row a_17 (g1 idx 8): source leaf e at iface 17.
+    s1, e1 = g1(8)
+    s2, e2 = g2(6)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_e_17_13)
+    s2, e2 = g2(10)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_e_17_16)
+    s2, e2 = g2(2)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_e_17_17)
+
+    # Row f_14 (g1 idx 9): source leaf g at iface 14.  g's interior faces
+    # (14, 15, 19) -> g's own g_in slots in Group 2:
+    #   g_14 = g2(7), g_15 = g2(9), g_19 = g2(5).
+    s1, e1 = g1(9)
+    s2, e2 = g2(7)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_g_14_14)
+    s2, e2 = g2(9)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_g_14_15)
+    s2, e2 = g2(5)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_g_14_19)
+
+    # Row h_15 (g1 idx 10): source leaf g at iface 15.
+    s1, e1 = g1(10)
+    s2, e2 = g2(7)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_g_15_14)
+    s2, e2 = g2(9)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_g_15_15)
+    s2, e2 = g2(5)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_g_15_19)
+
+    # Row c_19 (g1 idx 11): source leaf g at iface 19.
+    s1, e1 = g1(11)
+    s2, e2 = g2(7)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_g_19_14)
+    s2, e2 = g2(9)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_g_19_15)
+    s2, e2 = g2(5)
+    D_12 = D_12.at[s1:e1, s2:e2].set(T_g_19_19)
+
+    # ------------------------------------------------------------------
+    # Build D_21 (n_g2 x n_g1).  Symmetric structure to D_12: each row is
+    # a Group 2 g_int slot (g_in_alpha(f) for odd receiver alpha at face f);
+    # the T-blocks come from the OPPOSITE (even) source-leaf at the same
+    # interface, with columns indexed by the source-leaf's own three g_in
+    # slots in Group 1.
+    # ------------------------------------------------------------------
+    D_21 = jnp.zeros((n_g2, n_g1), dtype=dtype)
+
+    # Row b_9 (g2 idx 0): source leaf a at iface 9.  a's interior faces
+    # (9, 12, 17) -> a's own g_in slots in Group 1:
+    #   a_9 = g1(0), a_12 = g1(4), a_17 = g1(8).
+    s2, e2 = g2(0)
+    s1, e1 = g1(0)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_a_9_9)
+    s1, e1 = g1(4)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_a_9_12)
+    s1, e1 = g1(8)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_a_9_17)
+
+    # Row d_12 (g2 idx 1): source leaf a at iface 12.
+    s2, e2 = g2(1)
+    s1, e1 = g1(0)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_a_12_9)
+    s1, e1 = g1(4)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_a_12_12)
+    s1, e1 = g1(8)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_a_12_17)
+
+    # Row e_17 (g2 idx 2): source leaf a at iface 17.
+    s2, e2 = g2(2)
+    s1, e1 = g1(0)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_a_17_9)
+    s1, e1 = g1(4)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_a_17_12)
+    s1, e1 = g1(8)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_a_17_17)
+
+    # Row b_10 (g2 idx 3): source leaf c at iface 10.  c's interior faces
+    # (10, 11, 19) -> c's own g_in slots in Group 1:
+    #   c_10 = g1(1), c_11 = g1(3), c_19 = g1(11).
+    s2, e2 = g2(3)
+    s1, e1 = g1(1)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_c_10_10)
+    s1, e1 = g1(3)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_c_10_11)
+    s1, e1 = g1(11)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_c_10_19)
+
+    # Row d_11 (g2 idx 4): source leaf c at iface 11.
+    s2, e2 = g2(4)
+    s1, e1 = g1(1)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_c_11_10)
+    s1, e1 = g1(3)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_c_11_11)
+    s1, e1 = g1(11)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_c_11_19)
+
+    # Row g_19 (g2 idx 5): source leaf c at iface 19.
+    s2, e2 = g2(5)
+    s1, e1 = g1(1)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_c_19_10)
+    s1, e1 = g1(3)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_c_19_11)
+    s1, e1 = g1(11)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_c_19_19)
+
+    # Row e_13 (g2 idx 6): source leaf f at iface 13.  f's interior faces
+    # (13, 14, 18) -> f's own g_in slots in Group 1:
+    #   f_13 = g1(6), f_14 = g1(9), f_18 = g1(2).
+    s2, e2 = g2(6)
+    s1, e1 = g1(6)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_f_13_13)
+    s1, e1 = g1(9)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_f_13_14)
+    s1, e1 = g1(2)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_f_13_18)
+
+    # Row g_14 (g2 idx 7): source leaf f at iface 14.
+    s2, e2 = g2(7)
+    s1, e1 = g1(6)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_f_14_13)
+    s1, e1 = g1(9)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_f_14_14)
+    s1, e1 = g1(2)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_f_14_18)
+
+    # Row b_18 (g2 idx 8): source leaf f at iface 18.
+    s2, e2 = g2(8)
+    s1, e1 = g1(6)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_f_18_13)
+    s1, e1 = g1(9)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_f_18_14)
+    s1, e1 = g1(2)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_f_18_18)
+
+    # Row g_15 (g2 idx 9): source leaf h at iface 15.  h's interior faces
+    # (15, 16, 20) -> h's own g_in slots in Group 1:
+    #   h_15 = g1(10), h_16 = g1(7), h_20 = g1(5).
+    s2, e2 = g2(9)
+    s1, e1 = g1(10)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_h_15_15)
+    s1, e1 = g1(7)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_h_15_16)
+    s1, e1 = g1(5)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_h_15_20)
+
+    # Row e_16 (g2 idx 10): source leaf h at iface 16.
+    s2, e2 = g2(10)
+    s1, e1 = g1(10)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_h_16_15)
+    s1, e1 = g1(7)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_h_16_16)
+    s1, e1 = g1(5)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_h_16_20)
+
+    # Row d_20 (g2 idx 11): source leaf h at iface 20.
+    s2, e2 = g2(11)
+    s1, e1 = g1(10)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_h_20_15)
+    s1, e1 = g1(7)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_h_20_16)
+    s1, e1 = g1(5)
+    D_21 = D_21.at[s2:e2, s1:e1].set(T_h_20_20)
+
+    # ------------------------------------------------------------------
+    # Assemble h_int and h_ext.  h_int is the source-side outgoing data
+    # paired with each row of D: Group 1 rows use odd source-leaf h-pieces
+    # (b, d, e, g), Group 2 rows use even source-leaf h-pieces (a, c, f, h).
+    # The g_int slot at the same row stores g_in for the OPPOSITE leaf.
+    # ------------------------------------------------------------------
+    h_int = jnp.concatenate(
+        [
+            # Group 1 rows: receivers a_9, c_10, f_18, c_11, a_12, h_20,
+            #               f_13, h_16, a_17, f_14, h_15, c_19
+            # Sources (h-pieces): b/d/e/g grouped by source leaf.
+            h_b_9,
+            h_b_10,
+            h_b_18,
+            h_d_11,
+            h_d_12,
+            h_d_20,
+            h_e_13,
+            h_e_16,
+            h_e_17,
+            h_g_14,
+            h_g_15,
+            h_g_19,
+            # Group 2 rows: receivers b_9, d_12, e_17, b_10, d_11, g_19,
+            #               e_13, g_14, b_18, g_15, e_16, d_20
+            # Sources (h-pieces): a/c/f/h grouped by source leaf.
+            h_a_9,
+            h_a_12,
+            h_a_17,
+            h_c_10,
+            h_c_11,
+            h_c_19,
+            h_f_13,
+            h_f_14,
+            h_f_18,
+            h_h_15,
+            h_h_16,
+            h_h_20,
+        ],
+        axis=0,
+    )
+
+    h_ext = jnp.concatenate(
+        [h_a_1, h_b_2, h_c_3, h_d_4, h_e_5, h_f_6, h_g_7, h_h_8],
+        axis=0,
+    )
+
+    A_lst = [
+        T_a_1_1,
+        T_b_2_2,
+        T_c_3_3,
+        T_d_4_4,
+        T_e_5_5,
+        T_f_6_6,
+        T_g_7_7,
+        T_h_8_8,
+    ]
+
+    T, S, h_ext_out, g_tilde_int = assemble_merge_outputs_ItI(
+        A_lst, B, C, D_12, D_21, h_ext, h_int
+    )
+    return T, S, h_ext_out, g_tilde_int
+
+
+_vmapped_uniform_oct_merge_ItI = jax.vmap(
+    _uniform_oct_merge_ItI,
+    in_axes=(None, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+    out_axes=(0, 0, 0, 0),
+)
+
+
+@jax.jit
+def vmapped_uniform_oct_merge_ItI(
+    q_idxes: jnp.ndarray,
+    T_in: jnp.ndarray,
+    h_in: jnp.ndarray,
+) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """vmap'd ItI oct-merge over groups of 8 sibling leaves."""
+    n_leaves, a, b = T_in.shape
+    T_in = T_in.reshape((-1, 8, a, b))
+    if h_in.ndim == 2:
+        h_in = h_in.reshape((-1, 8, a))
+    else:
+        nsrc = h_in.shape[-1]
+        h_in = h_in.reshape((-1, 8, a, nsrc))
+
+    S, T_out, h_ext_out, g_tilde_int = _vmapped_uniform_oct_merge_ItI(
+        q_idxes,
+        T_in[:, 0],
+        T_in[:, 1],
+        T_in[:, 2],
+        T_in[:, 3],
+        T_in[:, 4],
+        T_in[:, 5],
+        T_in[:, 6],
+        T_in[:, 7],
+        h_in[:, 0],
+        h_in[:, 1],
+        h_in[:, 2],
+        h_in[:, 3],
+        h_in[:, 4],
+        h_in[:, 5],
+        h_in[:, 6],
+        h_in[:, 7],
+    )
+
+    return S, T_out, h_ext_out, g_tilde_int

--- a/tests/test_local_solve/test_local_solve_uniform_3D_ItI.py
+++ b/tests/test_local_solve/test_local_solve_uniform_3D_ItI.py
@@ -1,0 +1,185 @@
+"""Tests for the 3D uniform ItI local solve stage.
+
+Verifies:
+* Output shape contracts (single-source and multi-source).
+* Spectral convergence of the impedance-to-impedance (T) and
+  impedance-to-interior-solution (Y) maps against a manufactured plane-wave
+  Helmholtz solution.
+"""
+
+import numpy as np
+import jax.numpy as jnp
+import jax
+
+from jaxhps.local_solve._uniform_3D_ItI import (
+    local_solve_stage_uniform_3D_ItI,
+    get_ItI_3D,
+)
+from jaxhps._discretization_tree import DiscretizationNode3D
+from jaxhps._domain import Domain
+from jaxhps._pdeproblem import PDEProblem
+
+
+def _outward_normals(q: int) -> np.ndarray:
+    """Outward unit normal at each Gauss boundary node, ordered by face."""
+    n_dirs = np.zeros((6 * q * q, 3))
+    for f, nd in enumerate(
+        [[-1, 0, 0], [1, 0, 0], [0, -1, 0], [0, 1, 0], [0, 0, -1], [0, 0, 1]]
+    ):
+        n_dirs[f * q * q : (f + 1) * q * q] = nd
+    return n_dirs
+
+
+class Test_local_solve_stage_uniform_3D_ItI:
+    def test_shapes_single_leaf(self) -> None:
+        """Single-leaf shapes are correct for a single source term."""
+        p, q = 8, 6
+        eta = 4.0
+        root = DiscretizationNode3D(
+            xmin=-0.5, xmax=0.5, ymin=-0.5, ymax=0.5, zmin=-0.5, zmax=0.5
+        )
+        domain = Domain(p=p, q=q, root=root, L=0)
+        ones = np.ones((1, p**3))
+        src = np.zeros((1, p**3))
+        problem = PDEProblem(
+            domain=domain,
+            source=src,
+            D_xx_coefficients=ones,
+            D_yy_coefficients=ones,
+            D_zz_coefficients=ones,
+            I_coefficients=16.0 * ones,
+            use_ItI=True,
+            eta=eta,
+        )
+        Y, T, v, h = local_solve_stage_uniform_3D_ItI(problem)
+        assert Y.shape == (1, p**3, 6 * q**2)
+        assert T.shape == (1, 6 * q**2, 6 * q**2)
+        assert v.shape == (1, p**3)
+        assert h.shape == (1, 6 * q**2)
+        jax.clear_caches()
+
+    def test_shapes_multisource(self) -> None:
+        """Shapes propagate the source axis when given a multi-source RHS."""
+        p, q = 8, 6
+        eta = 4.0
+        n_src = 4
+        root = DiscretizationNode3D(
+            xmin=-0.5, xmax=0.5, ymin=-0.5, ymax=0.5, zmin=-0.5, zmax=0.5
+        )
+        domain = Domain(p=p, q=q, root=root, L=0)
+        ones = np.ones((1, p**3))
+        src = np.zeros((1, p**3, n_src))
+        problem = PDEProblem(
+            domain=domain,
+            source=src,
+            D_xx_coefficients=ones,
+            D_yy_coefficients=ones,
+            D_zz_coefficients=ones,
+            I_coefficients=16.0 * ones,
+            use_ItI=True,
+            eta=eta,
+        )
+        Y, T, v, h = local_solve_stage_uniform_3D_ItI(problem)
+        assert v.shape == (1, p**3, n_src)
+        assert h.shape == (1, 6 * q**2, n_src)
+        jax.clear_caches()
+
+    def test_planewave_spectral_convergence(self) -> None:
+        """Verify spectral convergence on the homogeneous Helmholtz equation
+        (Δ + κ²)u = 0 with manufactured plane-wave solution u = exp(i k·x),
+        |k| = κ. Asserts that the impedance-to-impedance and
+        impedance-to-interior maps converge spectrally as p increases.
+        """
+        kappa = 4.0
+        eta = kappa
+        k_vec = kappa * np.array([1.0, 2.0, 2.0]) / 3.0
+        half = 0.5
+        errors_T = []
+        errors_Y = []
+        for p, q in [(8, 6), (12, 10), (16, 12)]:
+            root = DiscretizationNode3D(
+                xmin=-half,
+                xmax=half,
+                ymin=-half,
+                ymax=half,
+                zmin=-half,
+                zmax=half,
+            )
+            domain = Domain(p=p, q=q, root=root, L=0)
+            ones = np.ones((1, p**3))
+            src = np.zeros((1, p**3))
+            problem = PDEProblem(
+                domain=domain,
+                source=src,
+                D_xx_coefficients=ones,
+                D_yy_coefficients=ones,
+                D_zz_coefficients=ones,
+                I_coefficients=kappa**2 * ones,
+                use_ItI=True,
+                eta=eta,
+            )
+            Y, T, _, _ = local_solve_stage_uniform_3D_ItI(problem)
+
+            cheby = np.asarray(domain.interior_points).reshape(-1, 3)
+            bp = np.asarray(domain.boundary_points).reshape(-1, 3)
+            u_cheby = np.exp(1j * (cheby @ k_vec))
+            u_g = np.exp(1j * (bp @ k_vec))
+            n_dirs = _outward_normals(q)
+            g_in = (1j * (n_dirs @ k_vec) + 1j * eta) * u_g
+            g_out = (1j * (n_dirs @ k_vec) - 1j * eta) * u_g
+
+            T0 = np.asarray(T[0])
+            Y0 = np.asarray(Y[0])
+            err_T = np.max(np.abs(T0 @ g_in - g_out)) / np.max(np.abs(g_out))
+            err_Y = np.max(np.abs(Y0 @ g_in - u_cheby)) / np.max(
+                np.abs(u_cheby)
+            )
+            errors_T.append(float(err_T))
+            errors_Y.append(float(err_Y))
+            jax.clear_caches()
+
+        # Loose absolute tolerances: the tightest (p=16) point should be near
+        # double precision, the coarsest (p=8) within 1e-3.
+        assert errors_T[0] < 1e-3
+        assert errors_T[2] < 1e-9
+        assert errors_Y[0] < 1e-3
+        assert errors_Y[2] < 1e-9
+        # Spectral convergence: errors should decrease monotonically.
+        assert errors_T[1] < errors_T[0]
+        assert errors_T[2] < errors_T[1]
+        assert errors_Y[1] < errors_Y[0]
+        assert errors_Y[2] < errors_Y[1]
+
+
+class Test_get_ItI_3D:
+    def test_shapes(self) -> None:
+        """Verify shapes from a single get_ItI_3D call with random operators."""
+        p, q = 6, 4
+        n_cheby = p**3
+        n_bdry = p**3 - (p - 2) ** 3
+        n_gauss = 6 * q**2
+
+        rng = np.random.default_rng(0)
+        diff_op = jnp.array(rng.normal(size=(n_cheby, n_cheby)))
+        source = jnp.array(rng.normal(size=(n_cheby, 1)))
+        P = jnp.array(rng.normal(size=(n_bdry, n_gauss)))
+        QH = jnp.array(
+            rng.normal(size=(n_gauss, n_cheby))
+            + 1j * rng.normal(size=(n_gauss, n_cheby))
+        )
+        G = jnp.array(
+            rng.normal(size=(n_bdry, n_cheby))
+            + 1j * rng.normal(size=(n_bdry, n_cheby))
+        )
+        T, Y, h, v = get_ItI_3D(
+            diff_operator=diff_op,
+            source_term=source,
+            P=P,
+            QH=QH,
+            G=G,
+        )
+        assert T.shape == (n_gauss, n_gauss)
+        assert Y.shape == (n_cheby, n_gauss)
+        assert h.shape == (n_gauss, 1)
+        assert v.shape == (n_cheby, 1)
+        jax.clear_caches()

--- a/tests/test_merge/test_merge_uniform_3D_ItI.py
+++ b/tests/test_merge/test_merge_uniform_3D_ItI.py
@@ -1,0 +1,269 @@
+import numpy as np
+import logging
+from jaxhps.merge._uniform_3D_ItI import (
+    merge_stage_uniform_3D_ItI,
+    _uniform_oct_merge_ItI,
+)
+import jax
+import jax.numpy as jnp
+
+from jaxhps.local_solve._uniform_3D_ItI import (
+    local_solve_stage_uniform_3D_ItI,
+)
+from jaxhps._discretization_tree import DiscretizationNode3D
+from jaxhps._domain import Domain
+from jaxhps._pdeproblem import PDEProblem
+
+
+class Test_merge_stage_uniform_3D_ItI:
+    def test_0(self, caplog) -> None:
+        # Smoke: shape contract for a single oct merge with constant
+        # Helmholtz coefficient (so the local solve has a well-defined
+        # ItI map).
+        caplog.set_level(logging.DEBUG)
+        p = 6
+        q = 4
+        l = 1
+        eta = 4.0
+        root = DiscretizationNode3D(
+            xmin=0.0,
+            xmax=1.0,
+            ymin=0.0,
+            ymax=1.0,
+            zmin=0.0,
+            zmax=1.0,
+            depth=0,
+        )
+        n_leaves = 8**l
+        domain = Domain(p=p, q=q, root=root, L=l)
+
+        d_xx = np.ones((n_leaves, p**3))
+        d_yy = np.ones((n_leaves, p**3))
+        d_zz = np.ones((n_leaves, p**3))
+        I_coeffs = np.full((n_leaves, p**3), eta**2)
+        source_term = np.zeros((n_leaves, p**3))
+
+        t = PDEProblem(
+            domain=domain,
+            D_xx_coefficients=d_xx,
+            D_yy_coefficients=d_yy,
+            D_zz_coefficients=d_zz,
+            I_coefficients=I_coeffs,
+            source=source_term,
+            use_ItI=True,
+            eta=eta,
+        )
+
+        Y_arr, T_arr, v, h = local_solve_stage_uniform_3D_ItI(t)
+        assert Y_arr.shape == (n_leaves, p**3, 6 * q**2)
+        assert T_arr.shape == (n_leaves, 6 * q**2, 6 * q**2)
+
+        S_arr_lst, g_tilde_lst = merge_stage_uniform_3D_ItI(
+            T_arr=T_arr, h_arr=h, l=l
+        )
+        assert len(S_arr_lst) == l
+        assert len(g_tilde_lst) == l
+        for i in range(l):
+            logging.debug(
+                "S[%d].shape = %s, g_tilde[%d].shape = %s",
+                i,
+                S_arr_lst[i].shape,
+                i,
+                g_tilde_lst[i].shape,
+            )
+            assert S_arr_lst[i].shape[-2] == g_tilde_lst[i].shape[-1]
+        jax.clear_caches()
+
+    def test_1(self, caplog) -> None:
+        # Multi-source smoke: same as test_0 with nsrc > 1.
+        caplog.set_level(logging.DEBUG)
+        p = 6
+        q = 4
+        l = 1
+        nsrc = 2
+        eta = 4.0
+        root = DiscretizationNode3D(
+            xmin=0.0,
+            xmax=1.0,
+            ymin=0.0,
+            ymax=1.0,
+            zmin=0.0,
+            zmax=1.0,
+            depth=0,
+        )
+        n_leaves = 8**l
+        domain = Domain(p=p, q=q, root=root, L=l)
+
+        d_xx = np.ones((n_leaves, p**3))
+        d_yy = np.ones((n_leaves, p**3))
+        d_zz = np.ones((n_leaves, p**3))
+        I_coeffs = np.full((n_leaves, p**3), eta**2)
+        source_term = np.zeros((n_leaves, p**3, nsrc))
+
+        t = PDEProblem(
+            domain=domain,
+            D_xx_coefficients=d_xx,
+            D_yy_coefficients=d_yy,
+            D_zz_coefficients=d_zz,
+            I_coefficients=I_coeffs,
+            source=source_term,
+            use_ItI=True,
+            eta=eta,
+        )
+
+        Y_arr, T_arr, v, h = local_solve_stage_uniform_3D_ItI(t)
+        assert Y_arr.shape == (n_leaves, p**3, 6 * q**2)
+        assert T_arr.shape == (n_leaves, 6 * q**2, 6 * q**2)
+
+        S_arr_lst, g_tilde_lst = merge_stage_uniform_3D_ItI(
+            T_arr=T_arr, h_arr=h, l=l
+        )
+        assert len(S_arr_lst) == l
+        assert len(g_tilde_lst) == l
+        jax.clear_caches()
+
+
+class Test_merge_planewave_correctness:
+    r"""Verify the merged T maps the global impedance trace correctly for a
+    manufactured plane-wave solution u = \exp(i k \cdot x) on the 8-leaf cube.
+
+    With (\Delta + \kappa^2) u = 0 satisfied identically,
+    \partial u / \partial n = i (k \cdot n) u.  The ItI traces are
+        g_in  = (\partial u / \partial n) + i \eta u = i (k \cdot n + \eta) u
+        g_out = (\partial u / \partial n) - i \eta u = i (k \cdot n - \eta) u
+    so we expect T_merged @ g_in \approx g_out at spectral precision.
+    """
+
+    @staticmethod
+    def _outward_normals_for_boundary(
+        boundary_points: np.ndarray, root
+    ) -> np.ndarray:
+        """Return unit outward normal at each boundary Gauss point."""
+        n = np.zeros_like(boundary_points)
+        eps = 1e-9
+        # Faces: x=xmin, x=xmax, y=ymin, y=ymax, z=zmin, z=zmax
+        n[np.abs(boundary_points[:, 0] - root.xmin) < eps] = [-1, 0, 0]
+        n[np.abs(boundary_points[:, 0] - root.xmax) < eps] = [1, 0, 0]
+        n[np.abs(boundary_points[:, 1] - root.ymin) < eps] = [0, -1, 0]
+        n[np.abs(boundary_points[:, 1] - root.ymax) < eps] = [0, 1, 0]
+        n[np.abs(boundary_points[:, 2] - root.zmin) < eps] = [0, 0, -1]
+        n[np.abs(boundary_points[:, 2] - root.zmax) < eps] = [0, 0, 1]
+        return n
+
+    def test_planewave(self, caplog) -> None:
+        caplog.set_level(logging.DEBUG)
+        kappa = 4.0
+        eta = kappa
+        k_vec = kappa * np.array([1.0, 2.0, 2.0]) / 3.0
+        results = []
+        for p, q in [(8, 6), (12, 8), (16, 10)]:
+            l = 1
+            root = DiscretizationNode3D(
+                xmin=-0.5,
+                xmax=0.5,
+                ymin=-0.5,
+                ymax=0.5,
+                zmin=-0.5,
+                zmax=0.5,
+                depth=0,
+            )
+            n_leaves = 8**l
+            domain = Domain(p=p, q=q, root=root, L=l)
+
+            ones = np.ones((n_leaves, p**3))
+            I_coeffs = kappa**2 * ones
+            src = np.zeros((n_leaves, p**3))
+
+            problem = PDEProblem(
+                domain=domain,
+                D_xx_coefficients=ones,
+                D_yy_coefficients=ones,
+                D_zz_coefficients=ones,
+                I_coefficients=I_coeffs,
+                source=src,
+                use_ItI=True,
+                eta=eta,
+            )
+
+            _, T_arr, _, h_arr = local_solve_stage_uniform_3D_ItI(problem)
+            S_lst, g_tilde_lst, T_top = merge_stage_uniform_3D_ItI(
+                T_arr=T_arr,
+                h_arr=h_arr,
+                l=l,
+                return_T=True,
+            )
+
+            bp = np.asarray(domain.boundary_points).reshape(-1, 3)
+            n_dirs = self._outward_normals_for_boundary(bp, root)
+            assert np.all(np.linalg.norm(n_dirs, axis=1) > 0.5), (
+                "Some boundary points were not assigned a normal"
+            )
+
+            u_b = np.exp(1j * (bp @ k_vec))
+            kn = n_dirs @ k_vec
+            g_in = 1j * (kn + eta) * u_b
+            g_out = 1j * (kn - eta) * u_b
+
+            T_top_np = np.asarray(T_top)
+            pred = T_top_np @ g_in
+            err = np.max(np.abs(pred - g_out)) / np.max(np.abs(g_out))
+            results.append((p, q, float(err)))
+            logging.debug("p=%d q=%d -> rel err = %.3e", p, q, err)
+            jax.clear_caches()
+
+        # Sanity: error should drop with p, and the tightest grid should
+        # reach near-spectral precision (well below 1e-3).
+        assert results[-1][2] < 1e-3, f"Spectral test failed: {results}"
+        assert results[-1][2] < results[0][2], (
+            f"Convergence not observed: {results}"
+        )
+
+
+class Test__uniform_oct_merge_ItI:
+    def test_0(self):
+        # Random complex inputs of the right shape - check shape contract.
+        q = 3
+        n_gauss_bdry = 6 * q**2
+        rng = np.random.default_rng(0)
+
+        def rand_T():
+            return rng.normal(
+                size=(n_gauss_bdry, n_gauss_bdry)
+            ) + 1j * rng.normal(size=(n_gauss_bdry, n_gauss_bdry))
+
+        def rand_h():
+            return rng.normal(size=(n_gauss_bdry,)) + 1j * rng.normal(
+                size=(n_gauss_bdry,)
+            )
+
+        T_a, T_b, T_c, T_d = rand_T(), rand_T(), rand_T(), rand_T()
+        T_e, T_f, T_g, T_h = rand_T(), rand_T(), rand_T(), rand_T()
+        h_a, h_b, h_c, h_d = rand_h(), rand_h(), rand_h(), rand_h()
+        h_e, h_f, h_g, h_h = rand_h(), rand_h(), rand_h(), rand_h()
+        q_idxes = jnp.arange(q)
+
+        S, T, h_ext, g_int = _uniform_oct_merge_ItI(
+            q_idxes,
+            jnp.asarray(T_a, dtype=jnp.complex128),
+            jnp.asarray(T_b, dtype=jnp.complex128),
+            jnp.asarray(T_c, dtype=jnp.complex128),
+            jnp.asarray(T_d, dtype=jnp.complex128),
+            jnp.asarray(T_e, dtype=jnp.complex128),
+            jnp.asarray(T_f, dtype=jnp.complex128),
+            jnp.asarray(T_g, dtype=jnp.complex128),
+            jnp.asarray(T_h, dtype=jnp.complex128),
+            jnp.asarray(h_a, dtype=jnp.complex128),
+            jnp.asarray(h_b, dtype=jnp.complex128),
+            jnp.asarray(h_c, dtype=jnp.complex128),
+            jnp.asarray(h_d, dtype=jnp.complex128),
+            jnp.asarray(h_e, dtype=jnp.complex128),
+            jnp.asarray(h_f, dtype=jnp.complex128),
+            jnp.asarray(h_g, dtype=jnp.complex128),
+            jnp.asarray(h_h, dtype=jnp.complex128),
+        )
+
+        assert T.shape == (24 * q**2, 24 * q**2)
+        assert S.shape == (24 * q**2, 24 * q**2)
+        assert h_ext.shape == (24 * q**2,)
+        assert g_int.shape == (24 * q**2,)
+        jax.clear_caches()

--- a/tests/test_pipeline_uniform_3D_ItI.py
+++ b/tests/test_pipeline_uniform_3D_ItI.py
@@ -1,0 +1,336 @@
+r"""End-to-end pipeline test for the uniform 3D ItI solver path.
+
+Builds the full solver (local solve + 3D oct merge) for the homogeneous
+constant-coefficient Helmholtz equation
+
+    \Delta u + \kappa^2 u = 0
+
+on the cube [-0.5, 0.5]^3 (one oct merge, L=1, 8 leaves), drives it with
+the impedance trace of the analytical plane-wave solution
+``u(x) = \exp(i k \cdot x)`` with ``|k| = \kappa``, runs the down-pass,
+and checks that the recovered interior solution matches the analytical
+one to spectral precision.
+"""
+
+import logging
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+from jaxhps._discretization_tree import DiscretizationNode3D
+from jaxhps._domain import Domain
+from jaxhps._pdeproblem import PDEProblem
+from jaxhps._build_solver import build_solver
+from jaxhps._solve import solve
+
+
+def _outward_normals_for_boundary(
+    boundary_points: np.ndarray, root
+) -> np.ndarray:
+    n = np.zeros_like(boundary_points)
+    eps = 1e-9
+    n[np.abs(boundary_points[:, 0] - root.xmin) < eps] = [-1, 0, 0]
+    n[np.abs(boundary_points[:, 0] - root.xmax) < eps] = [1, 0, 0]
+    n[np.abs(boundary_points[:, 1] - root.ymin) < eps] = [0, -1, 0]
+    n[np.abs(boundary_points[:, 1] - root.ymax) < eps] = [0, 1, 0]
+    n[np.abs(boundary_points[:, 2] - root.zmin) < eps] = [0, 0, -1]
+    n[np.abs(boundary_points[:, 2] - root.zmax) < eps] = [0, 0, 1]
+    return n
+
+
+def _exterior_point_source_solution(
+    points: np.ndarray, source_point: np.ndarray, kappa: float
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return u and grad u for exp(i k r) / r with source outside the box."""
+    rel = points - source_point
+    r = np.linalg.norm(rel, axis=-1)
+    u = np.exp(1j * kappa * r) / r
+    grad = (
+        u[..., None] * (1j * kappa - 1.0 / r)[..., None] * rel / r[..., None]
+    )
+    return u, grad
+
+
+class TestPipelineUniform3DItIPlanewave:
+    def test_planewave_pipeline(self, caplog) -> None:
+        caplog.set_level(logging.DEBUG)
+        kappa = 4.0
+        eta = kappa
+        # k_vec direction (1,2,2)/3 -> |k| = kappa
+        k_vec = kappa * np.array([1.0, 2.0, 2.0]) / 3.0
+        L = 1
+        results = []
+        for p, q in [(8, 6), (12, 8), (16, 10)]:
+            root = DiscretizationNode3D(
+                xmin=-0.5,
+                xmax=0.5,
+                ymin=-0.5,
+                ymax=0.5,
+                zmin=-0.5,
+                zmax=0.5,
+            )
+            n_leaves = 8**L
+            domain = Domain(p=p, q=q, root=root, L=L)
+
+            ones = np.ones((n_leaves, p**3))
+            I_coeffs = (kappa**2) * ones
+            src = np.zeros((n_leaves, p**3))
+
+            pde_problem = PDEProblem(
+                domain=domain,
+                D_xx_coefficients=ones,
+                D_yy_coefficients=ones,
+                D_zz_coefficients=ones,
+                I_coefficients=I_coeffs,
+                source=src,
+                use_ItI=True,
+                eta=eta,
+            )
+
+            T_top = build_solver(pde_problem, return_top_T=True)
+
+            bp = np.asarray(domain.boundary_points).reshape(-1, 3)
+            n_dirs = _outward_normals_for_boundary(bp, root)
+            assert np.all(np.linalg.norm(n_dirs, axis=1) > 0.5)
+
+            u_b = np.exp(1j * (bp @ k_vec))
+            kn = n_dirs @ k_vec
+            g_in = 1j * (kn + eta) * u_b
+            g_out = 1j * (kn - eta) * u_b
+
+            T_top_np = np.asarray(T_top)
+            pred_out = T_top_np @ g_in
+            err_top = np.max(np.abs(pred_out - g_out)) / np.max(np.abs(g_out))
+
+            # Run the down-pass
+            solns = solve(pde_problem, jnp.asarray(g_in))
+            assert solns.shape == (n_leaves, p**3)
+
+            # Compare to analytical plane-wave at every Cheby interior point
+            interior_pts = np.asarray(domain.interior_points).reshape(
+                n_leaves, p**3, 3
+            )
+            u_exact = np.exp(1j * (interior_pts @ k_vec))
+            u_solver = np.asarray(solns)
+
+            err_int = np.max(np.abs(u_solver - u_exact)) / np.max(
+                np.abs(u_exact)
+            )
+            results.append((p, q, float(err_top), float(err_int)))
+            logging.info(
+                "p=%d q=%d  T-err=%.3e  interior-err=%.3e",
+                p,
+                q,
+                err_top,
+                err_int,
+            )
+            jax.clear_caches()
+
+        # The finest grid should be near spectral precision and convergent.
+        assert results[-1][3] < 1e-3, (
+            f"Pipeline planewave test failed: {results}"
+        )
+        assert results[-1][3] < results[0][3], (
+            f"Convergence not observed: {results}"
+        )
+
+    def test_planewave_pipeline_L2(self, caplog) -> None:
+        """Same plane-wave test but on a 64-leaf (L=2) octree.  This
+        exercises the multi-level merge + multi-level down-pass."""
+        caplog.set_level(logging.DEBUG)
+        kappa = 4.0
+        eta = kappa
+        k_vec = kappa * np.array([1.0, 2.0, 2.0]) / 3.0
+        L = 2
+        p, q = 8, 6
+
+        root = DiscretizationNode3D(
+            xmin=-0.5,
+            xmax=0.5,
+            ymin=-0.5,
+            ymax=0.5,
+            zmin=-0.5,
+            zmax=0.5,
+        )
+        n_leaves = 8**L
+        domain = Domain(p=p, q=q, root=root, L=L)
+
+        ones = np.ones((n_leaves, p**3))
+        I_coeffs = (kappa**2) * ones
+        src = np.zeros((n_leaves, p**3))
+
+        pde_problem = PDEProblem(
+            domain=domain,
+            D_xx_coefficients=ones,
+            D_yy_coefficients=ones,
+            D_zz_coefficients=ones,
+            I_coefficients=I_coeffs,
+            source=src,
+            use_ItI=True,
+            eta=eta,
+        )
+
+        T_top = build_solver(pde_problem, return_top_T=True)
+
+        bp = np.asarray(domain.boundary_points).reshape(-1, 3)
+        n_dirs = _outward_normals_for_boundary(bp, root)
+        u_b = np.exp(1j * (bp @ k_vec))
+        kn = n_dirs @ k_vec
+        g_in = 1j * (kn + eta) * u_b
+        g_out = 1j * (kn - eta) * u_b
+
+        pred_out = np.asarray(T_top) @ g_in
+        err_top = np.max(np.abs(pred_out - g_out)) / np.max(np.abs(g_out))
+
+        solns = solve(pde_problem, jnp.asarray(g_in))
+        interior_pts = np.asarray(domain.interior_points).reshape(
+            n_leaves, p**3, 3
+        )
+        u_exact = np.exp(1j * (interior_pts @ k_vec))
+        u_solver = np.asarray(solns)
+        err_int = np.max(np.abs(u_solver - u_exact)) / np.max(np.abs(u_exact))
+        logging.info(
+            "L=2 p=%d q=%d  T-err=%.3e  interior-err=%.3e",
+            p,
+            q,
+            err_top,
+            err_int,
+        )
+        assert err_int < 1e-3, f"L=2 pipeline test failed: err={err_int}"
+
+    def test_exterior_point_source_impedance_trace(self, caplog) -> None:
+        r"""Curved outgoing Helmholtz field with exact impedance traces.
+
+        A point source outside the cube gives
+        ``u(x) = \exp(i \kappa |x-x_0|) / |x-x_0|``, which satisfies
+        ``\Delta u + \kappa^2 u = 0`` everywhere inside the cube.  Passing
+        its exact incoming impedance trace checks the same first-order
+        boundary convention as the plane-wave test, but with nonconstant
+        amplitude and curved phase on every face.
+        """
+        caplog.set_level(logging.DEBUG)
+        kappa = 4.0
+        eta = kappa
+        p, q, L = 12, 8, 1
+        source_point = np.array([1.35, -0.2, 0.8])
+        root = DiscretizationNode3D(
+            xmin=-0.5,
+            xmax=0.5,
+            ymin=-0.5,
+            ymax=0.5,
+            zmin=-0.5,
+            zmax=0.5,
+        )
+        n_leaves = 8**L
+        domain = Domain(p=p, q=q, root=root, L=L)
+
+        ones = np.ones((n_leaves, p**3))
+        problem = PDEProblem(
+            domain=domain,
+            D_xx_coefficients=ones,
+            D_yy_coefficients=ones,
+            D_zz_coefficients=ones,
+            I_coefficients=(kappa**2) * ones,
+            source=np.zeros((n_leaves, p**3)),
+            use_ItI=True,
+            eta=eta,
+        )
+
+        T_top = build_solver(problem, return_top_T=True)
+
+        bp = np.asarray(domain.boundary_points).reshape(-1, 3)
+        nrm = _outward_normals_for_boundary(bp, root)
+        u_b, grad_b = _exterior_point_source_solution(bp, source_point, kappa)
+        dn_u = np.einsum("ij,ij->i", grad_b, nrm)
+        g_in = dn_u + 1j * eta * u_b
+        g_out = dn_u - 1j * eta * u_b
+
+        pred_out = np.asarray(T_top) @ g_in
+        err_top = np.max(np.abs(pred_out - g_out)) / np.max(np.abs(g_out))
+
+        solns = np.asarray(solve(problem, jnp.asarray(g_in)))
+        interior_pts = np.asarray(domain.interior_points).reshape(
+            n_leaves, p**3, 3
+        )
+        u_exact, _ = _exterior_point_source_solution(
+            interior_pts, source_point, kappa
+        )
+        err_int = np.max(np.abs(solns - u_exact)) / np.max(np.abs(u_exact))
+
+        logging.info(
+            "exterior source p=%d q=%d T-err=%.3e interior-err=%.3e",
+            p,
+            q,
+            err_top,
+            err_int,
+        )
+        assert err_top < 1e-6, f"Exterior-source top T test failed: {err_top}"
+        assert err_int < 1e-6, (
+            f"Exterior-source pipeline test failed: {err_int}"
+        )
+        jax.clear_caches()
+
+    def test_manufactured_source_variable_coefficients(self, caplog) -> None:
+        """Manufactured solution with variable I coefficient and non-zero
+        source.  Verifies the source path of the pipeline (not exercised
+        by the homogeneous plane-wave test).
+
+        u(x,y,z) = sin(x) cos(y) sin(z)  ->  Lap u = -3 u
+        I(x,y,z) = kappa^2 + 2 + sin(x) cos(y) cos(z) x  (variable)
+        Equation: Lap u + I u = source  =>  source = (I - 3) u
+        """
+        caplog.set_level(logging.DEBUG)
+        kappa = 4.0
+        # Any non-zero eta works here; this is not an absorbing BC test.
+        eta = kappa
+        p, q, L = 12, 10, 1
+        root = DiscretizationNode3D(
+            xmin=-0.4,
+            xmax=0.4,
+            ymin=-0.4,
+            ymax=0.4,
+            zmin=-0.4,
+            zmax=0.4,
+        )
+        domain = Domain(p=p, q=q, root=root, L=L)
+        pts = np.asarray(domain.interior_points)
+        xg, yg, zg = pts[..., 0], pts[..., 1], pts[..., 2]
+        u_int = np.sin(xg) * np.cos(yg) * np.sin(zg)
+        I_var = kappa**2 + 2.0 + np.sin(xg) * np.cos(yg) * np.cos(zg) * xg
+        src = (-3.0 * u_int + I_var * u_int).astype(np.complex128)
+
+        n_leaves = pts.shape[0]
+        ones = np.ones((n_leaves, p**3))
+        problem = PDEProblem(
+            domain=domain,
+            D_xx_coefficients=ones,
+            D_yy_coefficients=ones,
+            D_zz_coefficients=ones,
+            I_coefficients=I_var.astype(np.complex128),
+            source=src,
+            use_ItI=True,
+            eta=eta,
+        )
+        build_solver(problem)
+
+        bp = np.asarray(domain.boundary_points).reshape(-1, 3)
+        nrm = _outward_normals_for_boundary(bp, root)
+        u_b = np.sin(bp[:, 0]) * np.cos(bp[:, 1]) * np.sin(bp[:, 2])
+        gn = (
+            np.cos(bp[:, 0]) * np.cos(bp[:, 1]) * np.sin(bp[:, 2]) * nrm[:, 0]
+            - np.sin(bp[:, 0])
+            * np.sin(bp[:, 1])
+            * np.sin(bp[:, 2])
+            * nrm[:, 1]
+            + np.sin(bp[:, 0])
+            * np.cos(bp[:, 1])
+            * np.cos(bp[:, 2])
+            * nrm[:, 2]
+        )
+        g_in = (gn + 1j * eta * u_b).astype(np.complex128)
+        solns = np.asarray(solve(problem, jnp.asarray(g_in)))
+        err = np.max(np.abs(solns - u_int)) / np.max(np.abs(u_int))
+        logging.info("manufactured-source variable-coeff err: %.3e", err)
+        assert err < 1e-9, f"manufactured-source test failed: err={err}"
+        jax.clear_caches()


### PR DESCRIPTION
## Summary
This PR adds a complete 3D ItI solver implementation to jaxhps, matching the existing 2D ItI functionality:

- 3D ItI precompute operators (Q_H, G, N matrices) with spectral convergence verification
- Local solve stage with Robin boundary conditions and shape contracts matching 2D ItI
- Eight-way octree merge for ItI maps with spectral convergence on plane-wave tests
- Down-pass and dispatch wiring for integration with build_solver/solve
- Variable-coefficient manufactured-source tests
- Accuracy check examples from upstream author
- Exterior-source ItI test cases

The implementation follows the same conventions as the existing 2D ItI code, with outer boundary using 1st-order Sommerfeld condition (eta = -κ).

#### Test plan
- Run the 3D ItI accuracy checks: `python examples/accuracy_check_3D_ItI_merges.py --problem_1 --problem_2 --p_vals 4 6 8 --l_vals 1 2`
- Run the unit tests for local solve, merge, and pipeline stages
- Verify spectral convergence on plane-wave tests

Generated with [Devin](https://cli.devin.ai/docs)